### PR TITLE
[quick-fix] Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "tuesday"
-groups:
-  development-dependencies:
-    dependency-type: "development"
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+


### PR DESCRIPTION
## Description

It looks my previous config was invalid. And GH does not provide easy way for config validation, apart from just merging it...
https://github.com/dependabot/dependabot-core/issues/4605


