### PR TITLE
Fix install from git branch - add typescript to devDependencies

### DIFF
--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -50,7 +50,8 @@
     "react": "^18.2.0",
     "typed-emitter": "^2.1.0",
     "typedoc": "^0.26.3",
-    "typedoc-plugin-mdn-links": "^3.2.2"
+    "typedoc-plugin-mdn-links": "^3.2.2",
+    "typescript": "^5.5.0"
   },
   "dependencies": {
     "@fishjam-dev/ts-client": "workspace:*",

--- a/packages/ts-client/package.json
+++ b/packages/ts-client/package.json
@@ -67,6 +67,7 @@
     "typedoc": "^0.26.3",
     "typedoc-plugin-external-resolver": "^1.0.3",
     "typedoc-plugin-mdn-links": "^3.2.2",
+    "typescript": "^5.5.0",
     "vitest": "^1.6.0",
     "zod": "^3.23.6"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -513,6 +513,7 @@ __metadata:
     typed-emitter: "npm:^2.1.0"
     typedoc: "npm:^0.26.3"
     typedoc-plugin-mdn-links: "npm:^3.2.2"
+    typescript: "npm:^5.5.0"
   languageName: unknown
   linkType: soft
 
@@ -536,6 +537,7 @@ __metadata:
     typedoc: "npm:^0.26.3"
     typedoc-plugin-external-resolver: "npm:^1.0.3"
     typedoc-plugin-mdn-links: "npm:^3.2.2"
+    typescript: "npm:^5.5.0"
     uuid: "npm:^10.0.0"
     vitest: "npm:^1.6.0"
     zod: "npm:^3.23.6"


### PR DESCRIPTION
## Description

This PR adds `TypeScript` to the `devDependencies` of the TypeScript and React packages.

## Motivation and Context

This change is necessary to enable the installation of web-clients from a Git branch.

## Types of changes

Bug fix (non-breaking change which fixes an issue)