### PR TITLE
Fce 394/track middleware

### DIFF
--- a/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
@@ -7,11 +7,11 @@ type DeviceControlsProps = {
   metadata: TrackMetadata;
 } & (
   | {
-      device: UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata>;
+      device: UserMediaAPI & TrackManager<TrackMetadata>;
       type: "audio";
     }
   | {
-      device: UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata>;
+      device: UserMediaAPI & TrackManager<TrackMetadata>;
       type: "video";
     }
 );

--- a/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
@@ -1,17 +1,17 @@
 import type { PeerStatus, UserMediaAPI } from "@fishjam-cloud/react-client";
 import type { TrackMetadata } from "./fishjamSetup";
-import type { GenericTrackManager } from "@fishjam-cloud/react-client";
+import type { TrackManager } from "@fishjam-cloud/react-client";
 
 type DeviceControlsProps = {
   status: PeerStatus;
   metadata: TrackMetadata;
 } & (
   | {
-      device: UserMediaAPI<TrackMetadata> & GenericTrackManager<TrackMetadata>;
+      device: UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata>;
       type: "audio";
     }
   | {
-      device: UserMediaAPI<TrackMetadata> & GenericTrackManager<TrackMetadata>;
+      device: UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata>;
       type: "video";
     }
 );
@@ -22,6 +22,7 @@ export const DeviceControls = ({
   status,
   metadata,
 }: DeviceControlsProps) => {
+  const isDeviceStreaming = !!device.getCurrentTrack()?.trackId;
   return (
     <div className="flex flex-col gap-2">
       <button
@@ -66,9 +67,7 @@ export const DeviceControls = ({
 
       <button
         className="btn btn-success btn-sm"
-        disabled={
-          status !== "joined" || !device?.stream || !!device?.broadcast?.trackId
-        }
+        disabled={status !== "joined" || !device?.stream || isDeviceStreaming}
         onClick={() => {
           device?.startStreaming(metadata);
         }}
@@ -78,9 +77,7 @@ export const DeviceControls = ({
 
       <button
         className="btn btn-error btn-sm"
-        disabled={
-          status !== "joined" || !device?.stream || !device?.broadcast?.trackId
-        }
+        disabled={status !== "joined" || !device?.stream || !isDeviceStreaming}
         onClick={() => {
           device?.stopStreaming();
         }}

--- a/examples/react-client/videoroom/package.json
+++ b/examples/react-client/videoroom/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@fishjam-cloud/react-client": "workspace:*",
+    "@mediapipe/tasks-vision": "^0.10.14",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/examples/react-client/videoroom/public/shaders/blur/fragment.glsl
+++ b/examples/react-client/videoroom/public/shaders/blur/fragment.glsl
@@ -1,0 +1,53 @@
+precision mediump float;
+varying vec2 v_pos;
+
+uniform sampler2D texture;
+uniform sampler2D resizedTexture;
+uniform sampler2D confidenceTexture;
+uniform vec2 u_size;
+
+const float gamma=1.8;
+
+const int CONV_SIDE=5;
+const float BLUR_RADIUS=float(CONV_SIDE);
+
+vec4 blur(sampler2D texture, sampler2D confidence, vec2 size, vec2 un) {
+    float n = 0.0;
+    vec3 res = vec3(0);
+    vec2 delta = 1.0  /size;
+    vec2 confidence_delta = 1.0 / size * 2.;
+
+    for(int x = -CONV_SIDE; x <= CONV_SIDE; x++){
+        for(int y = -CONV_SIDE; y <= CONV_SIDE; y++){
+        	vec2 u_ = un + delta * vec2(x,y);
+        	vec2 cu_=un + confidence_delta * vec2(x,y);
+            float c = 1.0 - texture2D(confidence, cu_).x;
+
+            if (distance(u_, un) <= BLUR_RADIUS) {
+                res += texture2D(texture, u_).rgb * c;
+                n += c;
+            }
+        }
+    }
+
+    if (n > 1.0) {
+      res /= n;
+    }
+
+    return vec4(res, 1.0);
+}
+
+void main() {
+  vec4 blurredValue = blur(resizedTexture, confidenceTexture, vec2(1280, 720) / 4., v_pos);
+  vec4 sharpValue = texture2D(texture, v_pos);
+  
+  vec4 filtered_confidence = smoothstep(0.1, 0.8, texture2D(confidenceTexture, v_pos));
+  
+  if (filtered_confidence.x < 0.5) {
+    gl_FragColor = blurredValue;
+  } else {
+    gl_FragColor = mix(blurredValue, sharpValue, filtered_confidence.x);
+  }
+}
+
+

--- a/examples/react-client/videoroom/public/shaders/blur/vertex.glsl
+++ b/examples/react-client/videoroom/public/shaders/blur/vertex.glsl
@@ -1,0 +1,7 @@
+attribute vec4 a_Position;
+varying vec2 v_pos;
+
+void main() {
+  gl_Position = a_Position;
+  v_pos = (a_Position.xy + 1.0) / 2.0;
+}

--- a/examples/react-client/videoroom/src/components/BlurToggle.tsx
+++ b/examples/react-client/videoroom/src/components/BlurToggle.tsx
@@ -1,0 +1,48 @@
+import { TrackMiddleware } from "@fishjam-cloud/react-client";
+import { useRef, useCallback } from "react";
+import { useCamera } from "../client";
+import { BlurProcessor } from "../utils/blur/BlurProcessor";
+import { Button } from "./Button";
+
+export function BlurToggle() {
+  const camera = useCamera();
+
+  const blurProcessorRef = useRef<BlurProcessor | null>(null);
+
+  const blurMiddleware: TrackMiddleware = useCallback(
+    (videoTrack: MediaStreamTrack | null) => {
+      if (!videoTrack) return videoTrack;
+
+      const stream = new MediaStream([videoTrack]);
+      const blurProcessor = new BlurProcessor(stream);
+      blurProcessorRef.current = blurProcessor;
+
+      return blurProcessor.stream.getVideoTracks()[0];
+    },
+    []
+  );
+
+  const clearBlurMiddleware = async () => {
+    await camera.setTrackMiddleware(null);
+    blurProcessorRef.current?.destroy();
+    blurProcessorRef.current = null;
+  };
+
+  const isMiddlewareSet = camera.currentTrackMiddleware === blurMiddleware;
+
+  const onClick = isMiddlewareSet
+    ? clearBlurMiddleware
+    : () => camera.setTrackMiddleware(blurMiddleware);
+
+  const title = isMiddlewareSet ? "Clear blur" : "Blur camera";
+
+  return (
+    <Button
+      className="w-full"
+      disabled={!camera.getCurrentTrack()?.trackId}
+      onClick={onClick}
+    >
+      {title}
+    </Button>
+  );
+}

--- a/examples/react-client/videoroom/src/components/BlurToggle.tsx
+++ b/examples/react-client/videoroom/src/components/BlurToggle.tsx
@@ -19,7 +19,7 @@ export function BlurToggle() {
 
       return blurProcessor.stream.getVideoTracks()[0];
     },
-    []
+    [],
   );
 
   const clearBlurMiddleware = async () => {

--- a/examples/react-client/videoroom/src/components/Button.tsx
+++ b/examples/react-client/videoroom/src/components/Button.tsx
@@ -1,10 +1,10 @@
 export const Button = (
-  props: React.ButtonHTMLAttributes<HTMLButtonElement>,
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>
 ) => {
   return (
     <button
-      className="px-2 py-1 bg-gray-500 text-white rounded-md disabled:bg-gray-300"
       {...props}
+      className={`px-2 py-1 bg-gray-500 text-white rounded-md disabled:bg-gray-300 ${props.className}`}
     />
   );
 };

--- a/examples/react-client/videoroom/src/components/Button.tsx
+++ b/examples/react-client/videoroom/src/components/Button.tsx
@@ -1,5 +1,5 @@
 export const Button = (
-  props: React.ButtonHTMLAttributes<HTMLButtonElement>
+  props: React.ButtonHTMLAttributes<HTMLButtonElement>,
 ) => {
   return (
     <button

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -11,7 +11,7 @@ import { Button } from "./Button";
 import { BlurProcessor } from "./utils/blur/BlurProcessor";
 
 interface DeviceSelectProps {
-  device: UserMediaAPI<unknown> & TrackManager<unknown>;
+  device: UserMediaAPI & TrackManager<unknown>;
 }
 
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
@@ -28,7 +28,7 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
 
       return blurProcessor.stream.getVideoTracks()[0];
     },
-    []
+    [],
   );
 
   const clearBlurMiddleware = async () => {

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -19,7 +19,9 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
   const blurProcessorRef = useRef<BlurProcessor | null>(null);
 
   const blurMiddleware: TrackMiddleware = useCallback(
-    (videoTrack: MediaStreamTrack) => {
+    (videoTrack: MediaStreamTrack | null) => {
+      if (!videoTrack) return videoTrack;
+
       const stream = new MediaStream([videoTrack]);
       const blurProcessor = new BlurProcessor(stream);
       blurProcessorRef.current = blurProcessor;

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -3,7 +3,7 @@ import AudioVisualizer from "./AudioVisualizer";
 import { useCamera, useMicrophone, useScreenShare, useStatus } from "../client";
 import VideoPlayer from "./VideoPlayer";
 import {
-  GenericTrackManager,
+  TrackManager,
   TrackMiddleware,
   UserMediaAPI,
 } from "@fishjam-cloud/react-client";
@@ -11,7 +11,7 @@ import { Button } from "./Button";
 import { BlurProcessor } from "./utils/blur/BlurProcessor";
 
 interface DeviceSelectProps {
-  device: UserMediaAPI<unknown> & GenericTrackManager<unknown>;
+  device: UserMediaAPI<unknown> & TrackManager<unknown>;
 }
 
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
@@ -39,6 +39,8 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
 
   const isMiddlewareSet = device.currentTrackMiddleware === blurMiddleware;
 
+  const isTrackStreamed = !!device.getCurrentTrack()?.trackId;
+
   return (
     <div className="flex gap-4 justify-between">
       <select
@@ -52,7 +54,7 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
         ))}
       </select>
 
-      {device.broadcast?.trackId ? (
+      {isTrackStreamed ? (
         <Button
           disabled={!hasJoinedRoom}
           onClick={async () => {

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react";
+import { FC, useCallback, useRef } from "react";
 import AudioVisualizer from "./AudioVisualizer";
 import { useCamera, useMicrophone, useScreenShare, useStatus } from "../client";
 import VideoPlayer from "./VideoPlayer";
@@ -14,15 +14,28 @@ interface DeviceSelectProps {
   device: UserMediaAPI<unknown> & GenericTrackManager<unknown>;
 }
 
-const blurMiddleware: TrackMiddleware = (videoTrack) => {
-  const stream = new MediaStream([videoTrack]);
-  const blurredStream = new BlurProcessor(stream);
-
-  return blurredStream.track;
-};
-
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
   const hasJoinedRoom = useStatus() === "joined";
+  const blurProcessorRef = useRef<BlurProcessor | null>(null);
+
+  const blurMiddleware: TrackMiddleware = useCallback(
+    (videoTrack: MediaStreamTrack) => {
+      const stream = new MediaStream([videoTrack]);
+      const blurProcessor = new BlurProcessor(stream);
+      blurProcessorRef.current = blurProcessor;
+
+      return blurProcessor.stream.getVideoTracks()[0];
+    },
+    []
+  );
+
+  const clearBlurMiddleware = async () => {
+    await device.setTrackMiddleware(null);
+    blurProcessorRef.current?.destroy();
+    blurProcessorRef.current = null;
+  };
+
+  const isMiddlewareSet = device.currentTrackMiddleware === blurMiddleware;
 
   return (
     <div className="flex gap-4 justify-between">
@@ -57,14 +70,25 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
         </Button>
       )}
 
-      <Button
-        disabled={!device.stream}
-        onClick={async () => {
-          await device.setTrackMiddleware(blurMiddleware);
-        }}
-      >
-        Blur
-      </Button>
+      {isMiddlewareSet ? (
+        <Button
+          disabled={!device.stream}
+          onClick={async () => {
+            await clearBlurMiddleware();
+          }}
+        >
+          Unblur
+        </Button>
+      ) : (
+        <Button
+          disabled={!device.stream}
+          onClick={async () => {
+            await device.setTrackMiddleware(blurMiddleware);
+          }}
+        >
+          Blur
+        </Button>
+      )}
     </div>
   );
 };

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -2,12 +2,24 @@ import { FC } from "react";
 import AudioVisualizer from "./AudioVisualizer";
 import { useCamera, useMicrophone, useScreenShare, useStatus } from "../client";
 import VideoPlayer from "./VideoPlayer";
-import { GenericTrackManager, UserMediaAPI } from "@fishjam-cloud/react-client";
+import {
+  GenericTrackManager,
+  TrackMiddleware,
+  UserMediaAPI,
+} from "@fishjam-cloud/react-client";
 import { Button } from "./Button";
+import { BlurProcessor } from "./utils/blur/BlurProcessor";
 
 interface DeviceSelectProps {
   device: UserMediaAPI<unknown> & GenericTrackManager<unknown>;
 }
+
+const blurMiddleware: TrackMiddleware = (videoTrack) => {
+  const stream = new MediaStream([videoTrack]);
+  const blurredStream = new BlurProcessor(stream);
+
+  return blurredStream.track;
+};
 
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
   const hasJoinedRoom = useStatus() === "joined";
@@ -44,6 +56,15 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
           Stream
         </Button>
       )}
+
+      <Button
+        disabled={!device.stream}
+        onClick={async () => {
+          await device.setTrackMiddleware(blurMiddleware);
+        }}
+      >
+        Blur
+      </Button>
     </div>
   );
 };

--- a/examples/react-client/videoroom/src/components/VideoPlayer.tsx
+++ b/examples/react-client/videoroom/src/components/VideoPlayer.tsx
@@ -10,7 +10,7 @@ const VideoPlayer: FC<VideoPlayerProps> = ({ stream, peerId, ...props }) => {
 
   useEffect(() => {
     if (!videoRef.current) return;
-    videoRef.current.srcObject = stream || null;
+    videoRef.current.srcObject = stream ?? null;
   }, [stream]);
 
   return (

--- a/examples/react-client/videoroom/src/utils/blur/BlurProcessor.tsx
+++ b/examples/react-client/videoroom/src/utils/blur/BlurProcessor.tsx
@@ -1,4 +1,8 @@
-import { FilesetResolver, ImageSegmenter, ImageSegmenterCallback } from "@mediapipe/tasks-vision";
+import {
+  FilesetResolver,
+  ImageSegmenter,
+  ImageSegmenterCallback,
+} from "@mediapipe/tasks-vision";
 import BlurWorker from "./BlurProcessorWorker?worker";
 
 export class BlurProcessor {
@@ -58,20 +62,20 @@ export class BlurProcessor {
     this.initMediaPipe();
     this.initWebgl();
 
-    document.addEventListener("visibilitychange", this.visibilityListener)
+    document.addEventListener("visibilitychange", this.visibilityListener);
     this.worker.onmessage = this.onFrameCallback;
     this.video.requestVideoFrameCallback(this.onFrameCallback);
   }
 
   private visibilityListener = () => {
-      if (document.visibilityState === "visible") {
-        this.worksInForeground = true;
-        this.worker.postMessage({type: "stop"});
-      } else {
-        this.worksInForeground = false;
-        this.worker.postMessage({type: "start", fps: this.fps});
-      }
+    if (document.visibilityState === "visible") {
+      this.worksInForeground = true;
+      this.worker.postMessage({ type: "stop" });
+    } else {
+      this.worksInForeground = false;
+      this.worker.postMessage({ type: "start", fps: this.fps });
     }
+  };
 
   private async initMediaPipe() {
     const wasm = await FilesetResolver.forVisionTasks(
@@ -92,8 +96,16 @@ export class BlurProcessor {
     const gl = this.webglCanvasCtx;
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
     const program = gl.createProgram()!;
-    const vs = await this.loadShader(gl, gl.VERTEX_SHADER, "/shaders/blur/vertex.glsl");
-    const fs = await this.loadShader(gl, gl.FRAGMENT_SHADER, "/shaders/blur/fragment.glsl");
+    const vs = await this.loadShader(
+      gl,
+      gl.VERTEX_SHADER,
+      "/shaders/blur/vertex.glsl"
+    );
+    const fs = await this.loadShader(
+      gl,
+      gl.FRAGMENT_SHADER,
+      "/shaders/blur/fragment.glsl"
+    );
     gl.attachShader(program, vs);
     gl.attachShader(program, fs);
     gl.linkProgram(program);
@@ -103,7 +115,11 @@ export class BlurProcessor {
 
     const vertexBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
-    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -3, -1, 1, 3, 1]), gl.STREAM_DRAW);
+    gl.bufferData(
+      gl.ARRAY_BUFFER,
+      new Float32Array([-1, -3, -1, 1, 3, 1]),
+      gl.STREAM_DRAW
+    );
     const a_Position = gl.getAttribLocation(program, "a_Position");
     gl.vertexAttribPointer(a_Position, 2, gl.FLOAT, false, 0, 0);
     gl.enableVertexAttribArray(a_Position);
@@ -123,7 +139,10 @@ export class BlurProcessor {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
-    const confidenceTextureLoc = gl.getUniformLocation(program, "confidenceTexture");
+    const confidenceTextureLoc = gl.getUniformLocation(
+      program,
+      "confidenceTexture"
+    );
     gl.uniform1i(confidenceTextureLoc, 1);
 
     const resizedTexture = gl.createTexture()!;
@@ -136,7 +155,11 @@ export class BlurProcessor {
     gl.uniform1i(resizedTextureLoc, 2);
   }
 
-  private async loadShader(gl: WebGL2RenderingContext, type: number, path: string): Promise<WebGLShader> {
+  private async loadShader(
+    gl: WebGL2RenderingContext,
+    type: number,
+    path: string
+  ): Promise<WebGLShader> {
     const shader = gl.createShader(type)!;
     gl.shaderSource(shader, await (await fetch(path)).text());
     gl.compileShader(shader);
@@ -178,10 +201,20 @@ export class BlurProcessor {
 
     this.canvasCtx.drawImage(this.video, 0, 0, this.width / 2, this.height / 2);
 
-    this.resizedCanvasCtx.drawImage(this.canvas, 0, 0, this.width / 4, this.height / 4);
+    this.resizedCanvasCtx.drawImage(
+      this.canvas,
+      0,
+      0,
+      this.width / 4,
+      this.height / 4
+    );
 
     this.prevVideoTime = this.video.currentTime;
-    this.segmenter.segmentForVideo(this.canvas, this.video.currentTime * 1000, this.onSegmentationReady);
+    this.segmenter.segmentForVideo(
+      this.canvas,
+      this.video.currentTime * 1000,
+      this.onSegmentationReady
+    );
 
     if (this.worksInForeground) {
       this.video.requestVideoFrameCallback(this.onFrameCallback);
@@ -193,7 +226,14 @@ export class BlurProcessor {
 
     const gl = this.webglCanvasCtx;
     gl.activeTexture(gl.TEXTURE0);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this.video);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      this.video
+    );
 
     gl.activeTexture(gl.TEXTURE1);
     gl.texImage2D(
@@ -209,7 +249,14 @@ export class BlurProcessor {
     );
 
     gl.activeTexture(gl.TEXTURE2);
-    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this.resizedCanvas);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      this.resizedCanvas
+    );
 
     gl.drawArrays(gl.TRIANGLES, 0, 3);
   };

--- a/examples/react-client/videoroom/src/utils/blur/BlurProcessor.tsx
+++ b/examples/react-client/videoroom/src/utils/blur/BlurProcessor.tsx
@@ -1,0 +1,216 @@
+import { FilesetResolver, ImageSegmenter, ImageSegmenterCallback } from "@mediapipe/tasks-vision";
+import BlurWorker from "./BlurProcessorWorker?worker";
+
+export class BlurProcessor {
+  private width: number;
+  private height: number;
+
+  // stores frames of the video
+  private canvas: HTMLCanvasElement;
+  private canvasCtx: CanvasRenderingContext2D;
+
+  // downsamples camera feed, used to blur background
+  private resizedCanvas: HTMLCanvasElement;
+  private resizedCanvasCtx: CanvasRenderingContext2D;
+
+  private webglCanvas: HTMLCanvasElement;
+  private webglCanvasCtx: WebGL2RenderingContext;
+
+  private segmenter: ImageSegmenter | null = null;
+  private prevVideoTime: number = 0;
+  stream: MediaStream;
+  track: MediaStreamTrack;
+  private video: HTMLVideoElement;
+  private worker = new BlurWorker();
+  private worksInForeground = true;
+  private fps: number;
+  private destroyed = false;
+
+  constructor(video: MediaStream) {
+    const trackSettings = video.getVideoTracks()[0].getSettings();
+    this.width = trackSettings.width ?? 1280;
+    this.height = trackSettings.height ?? 720;
+
+    this.canvas = document.createElement("canvas");
+    this.canvas.setAttribute("width", "" + this.width / 2);
+    this.canvas.setAttribute("height", "" + this.height / 2);
+    this.canvasCtx = this.canvas.getContext("2d")!;
+
+    this.resizedCanvas = document.createElement("canvas");
+    this.resizedCanvas.setAttribute("width", "" + this.width / 4);
+    this.resizedCanvas.setAttribute("height", "" + this.height / 4);
+    this.resizedCanvasCtx = this.resizedCanvas.getContext("2d")!;
+
+    this.webglCanvas = document.createElement("canvas");
+    this.webglCanvas.setAttribute("width", "" + this.width);
+    this.webglCanvas.setAttribute("height", "" + this.height);
+    this.webglCanvasCtx = this.webglCanvas.getContext("webgl2")!;
+
+    this.fps = trackSettings.frameRate ?? 24;
+    this.stream = this.webglCanvas.captureStream(this.fps);
+    this.track = this.stream.getVideoTracks()[0];
+
+    this.video = document.createElement("video");
+    this.video.srcObject = video;
+    this.video.muted = true;
+    this.video.play();
+
+    this.initMediaPipe();
+    this.initWebgl();
+
+    document.addEventListener("visibilitychange", this.visibilityListener)
+    this.worker.onmessage = this.onFrameCallback;
+    this.video.requestVideoFrameCallback(this.onFrameCallback);
+  }
+
+  private visibilityListener = () => {
+      if (document.visibilityState === "visible") {
+        this.worksInForeground = true;
+        this.worker.postMessage({type: "stop"});
+      } else {
+        this.worksInForeground = false;
+        this.worker.postMessage({type: "start", fps: this.fps});
+      }
+    }
+
+  private async initMediaPipe() {
+    const wasm = await FilesetResolver.forVisionTasks(
+      "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.11/wasm"
+    );
+    this.segmenter = await ImageSegmenter.createFromOptions(wasm, {
+      baseOptions: {
+        modelAssetPath:
+          "https://storage.googleapis.com/mediapipe-models/image_segmenter/selfie_segmenter_landscape/float16/latest/selfie_segmenter_landscape.tflite",
+      },
+      runningMode: "VIDEO",
+      outputCategoryMask: true,
+      outputConfidenceMasks: true,
+    });
+  }
+
+  private async initWebgl() {
+    const gl = this.webglCanvasCtx;
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, true);
+    const program = gl.createProgram()!;
+    const vs = await this.loadShader(gl, gl.VERTEX_SHADER, "/shaders/blur/vertex.glsl");
+    const fs = await this.loadShader(gl, gl.FRAGMENT_SHADER, "/shaders/blur/fragment.glsl");
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.useProgram(program);
+    gl.viewport(0, 0, this.width, this.height);
+    gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
+
+    const vertexBuffer = gl.createBuffer();
+    gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -3, -1, 1, 3, 1]), gl.STREAM_DRAW);
+    const a_Position = gl.getAttribLocation(program, "a_Position");
+    gl.vertexAttribPointer(a_Position, 2, gl.FLOAT, false, 0, 0);
+    gl.enableVertexAttribArray(a_Position);
+
+    const texture = gl.createTexture()!;
+    gl.activeTexture(gl.TEXTURE0);
+    gl.bindTexture(gl.TEXTURE_2D, texture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    const textureLoc = gl.getUniformLocation(program, "texture");
+    gl.uniform1i(textureLoc, 0);
+
+    const confidenceTexture = gl.createTexture()!;
+    gl.activeTexture(gl.TEXTURE1);
+    gl.bindTexture(gl.TEXTURE_2D, confidenceTexture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    const confidenceTextureLoc = gl.getUniformLocation(program, "confidenceTexture");
+    gl.uniform1i(confidenceTextureLoc, 1);
+
+    const resizedTexture = gl.createTexture()!;
+    gl.activeTexture(gl.TEXTURE2);
+    gl.bindTexture(gl.TEXTURE_2D, resizedTexture);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+    const resizedTextureLoc = gl.getUniformLocation(program, "resizedTexture");
+    gl.uniform1i(resizedTextureLoc, 2);
+  }
+
+  private async loadShader(gl: WebGL2RenderingContext, type: number, path: string): Promise<WebGLShader> {
+    const shader = gl.createShader(type)!;
+    gl.shaderSource(shader, await (await fetch(path)).text());
+    gl.compileShader(shader);
+
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+      console.error("Failed to compile shader", {
+        path: path,
+        error: gl.getShaderInfoLog(shader),
+      });
+
+      throw "Failed to compile shader";
+    }
+
+    return shader;
+  }
+
+  destroy() {
+    document.removeEventListener("visibilitychange", this.visibilityListener);
+    this.worker.terminate();
+    this.track.stop();
+    this.segmenter?.close();
+    this.destroyed = true;
+
+    this.canvas.remove();
+    this.resizedCanvas.remove();
+    this.webglCanvas.remove();
+    this.video.remove();
+  }
+
+  private onFrameCallback = () => {
+    if (this.destroyed) return;
+
+    if (!this.segmenter || this.prevVideoTime >= this.video.currentTime) {
+      if (this.worksInForeground) {
+        this.video.requestVideoFrameCallback(this.onFrameCallback);
+      }
+      return;
+    }
+
+    this.canvasCtx.drawImage(this.video, 0, 0, this.width / 2, this.height / 2);
+
+    this.resizedCanvasCtx.drawImage(this.canvas, 0, 0, this.width / 4, this.height / 4);
+
+    this.prevVideoTime = this.video.currentTime;
+    this.segmenter.segmentForVideo(this.canvas, this.video.currentTime * 1000, this.onSegmentationReady);
+
+    if (this.worksInForeground) {
+      this.video.requestVideoFrameCallback(this.onFrameCallback);
+    }
+  };
+
+  private onSegmentationReady: ImageSegmenterCallback = (result) => {
+    const confidenceMask = result.confidenceMasks![0];
+
+    const gl = this.webglCanvasCtx;
+    gl.activeTexture(gl.TEXTURE0);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this.video);
+
+    gl.activeTexture(gl.TEXTURE1);
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.LUMINANCE,
+      confidenceMask.width,
+      confidenceMask.height,
+      0,
+      gl.LUMINANCE,
+      gl.UNSIGNED_BYTE,
+      confidenceMask.getAsUint8Array()
+    );
+
+    gl.activeTexture(gl.TEXTURE2);
+    gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, this.resizedCanvas);
+
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  };
+}

--- a/examples/react-client/videoroom/src/utils/blur/BlurProcessor.tsx
+++ b/examples/react-client/videoroom/src/utils/blur/BlurProcessor.tsx
@@ -79,7 +79,7 @@ export class BlurProcessor {
 
   private async initMediaPipe() {
     const wasm = await FilesetResolver.forVisionTasks(
-      "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.11/wasm"
+      "https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.11/wasm",
     );
     this.segmenter = await ImageSegmenter.createFromOptions(wasm, {
       baseOptions: {
@@ -99,12 +99,12 @@ export class BlurProcessor {
     const vs = await this.loadShader(
       gl,
       gl.VERTEX_SHADER,
-      "/shaders/blur/vertex.glsl"
+      "/shaders/blur/vertex.glsl",
     );
     const fs = await this.loadShader(
       gl,
       gl.FRAGMENT_SHADER,
-      "/shaders/blur/fragment.glsl"
+      "/shaders/blur/fragment.glsl",
     );
     gl.attachShader(program, vs);
     gl.attachShader(program, fs);
@@ -118,7 +118,7 @@ export class BlurProcessor {
     gl.bufferData(
       gl.ARRAY_BUFFER,
       new Float32Array([-1, -3, -1, 1, 3, 1]),
-      gl.STREAM_DRAW
+      gl.STREAM_DRAW,
     );
     const a_Position = gl.getAttribLocation(program, "a_Position");
     gl.vertexAttribPointer(a_Position, 2, gl.FLOAT, false, 0, 0);
@@ -141,7 +141,7 @@ export class BlurProcessor {
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
     const confidenceTextureLoc = gl.getUniformLocation(
       program,
-      "confidenceTexture"
+      "confidenceTexture",
     );
     gl.uniform1i(confidenceTextureLoc, 1);
 
@@ -158,7 +158,7 @@ export class BlurProcessor {
   private async loadShader(
     gl: WebGL2RenderingContext,
     type: number,
-    path: string
+    path: string,
   ): Promise<WebGLShader> {
     const shader = gl.createShader(type)!;
     gl.shaderSource(shader, await (await fetch(path)).text());
@@ -206,14 +206,14 @@ export class BlurProcessor {
       0,
       0,
       this.width / 4,
-      this.height / 4
+      this.height / 4,
     );
 
     this.prevVideoTime = this.video.currentTime;
     this.segmenter.segmentForVideo(
       this.canvas,
       this.video.currentTime * 1000,
-      this.onSegmentationReady
+      this.onSegmentationReady,
     );
 
     if (this.worksInForeground) {
@@ -232,7 +232,7 @@ export class BlurProcessor {
       gl.RGBA,
       gl.RGBA,
       gl.UNSIGNED_BYTE,
-      this.video
+      this.video,
     );
 
     gl.activeTexture(gl.TEXTURE1);
@@ -245,7 +245,7 @@ export class BlurProcessor {
       0,
       gl.LUMINANCE,
       gl.UNSIGNED_BYTE,
-      confidenceMask.getAsUint8Array()
+      confidenceMask.getAsUint8Array(),
     );
 
     gl.activeTexture(gl.TEXTURE2);
@@ -255,7 +255,7 @@ export class BlurProcessor {
       gl.RGBA,
       gl.RGBA,
       gl.UNSIGNED_BYTE,
-      this.resizedCanvas
+      this.resizedCanvas,
     );
 
     gl.drawArrays(gl.TRIANGLES, 0, 3);

--- a/examples/react-client/videoroom/src/utils/blur/BlurProcessorWorker.ts
+++ b/examples/react-client/videoroom/src/utils/blur/BlurProcessorWorker.ts
@@ -1,0 +1,17 @@
+let intervalId: number;
+
+self.onmessage = (event) => {
+  if (event.data.type === "start") {
+    intervalId = self.setInterval(animationLoop, 1_000 / event.data.fps);
+  } else if (event.data.type === "stop") {
+    self.clearInterval(intervalId);
+  }
+};
+
+self.onclose = () => {
+  self.clearInterval(intervalId);
+}
+
+function animationLoop() {
+  self.postMessage("tick");
+}

--- a/examples/react-client/videoroom/src/utils/blur/BlurProcessorWorker.ts
+++ b/examples/react-client/videoroom/src/utils/blur/BlurProcessorWorker.ts
@@ -10,7 +10,7 @@ self.onmessage = (event) => {
 
 self.onclose = () => {
   self.clearInterval(intervalId);
-}
+};
 
 function animationLoop() {
   self.postMessage("tick");

--- a/packages/react-client/src/Client.ts
+++ b/packages/react-client/src/Client.ts
@@ -42,7 +42,7 @@ export type ClientApi<PeerMetadata, TrackMetadata> = {
   bandwidthEstimation: bigint;
   status: PeerStatus;
   media: MediaState | null;
-  devices: Devices<TrackMetadata>;
+  devices: Devices;
 
   isReconnecting: () => boolean;
 };
@@ -313,7 +313,7 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
   public bandwidthEstimation: bigint = BigInt(0);
   public status: PeerStatus = null;
   public media: MediaState | null = null;
-  public devices: Devices<TrackMetadata>;
+  public devices: Devices;
 
   public reconnectionStatus: ReconnectionStatus = "idle";
 
@@ -829,7 +829,7 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
       localTracks[track.trackId] = this.trackContextToTrack(track);
     });
 
-    const devices: Devices<TrackMetadata> = {
+    const devices: Devices = {
       camera: {
         status: deviceManagerSnapshot?.video?.devicesStatus || null,
         stream: deviceManagerSnapshot?.video.media?.stream || null,

--- a/packages/react-client/src/Client.ts
+++ b/packages/react-client/src/Client.ts
@@ -352,6 +352,12 @@ export class Client<PeerMetadata, TrackMetadata> extends (EventEmitter as {
 
     this.stateToSnapshot();
 
+    this.tsClient.on("disconnected", () => {
+      this.status = null;
+      this.stateToSnapshot();
+      this.emit("disconnected", this);
+    });
+
     this.tsClient.on("socketOpen", (event) => {
       this.status = "connected";
       this.stateToSnapshot();

--- a/packages/react-client/src/DeviceManager.ts
+++ b/packages/react-client/src/DeviceManager.ts
@@ -1,4 +1,4 @@
-import type { DeviceManagerConfig, DeviceState, GenericMediaManager, StorageConfig, DeviceError } from "./types";
+import type { DeviceManagerConfig, DeviceState, MediaManager, StorageConfig, DeviceError } from "./types";
 
 import { prepareMediaTrackConstraints, toMediaTrackConstraints } from "./constraints";
 
@@ -29,7 +29,7 @@ export type DeviceManagerStatus = "uninitialized" | "initializing" | "initialize
 
 export class DeviceManager
   extends (EventEmitter as new () => TypedEmitter<DeviceManagerEvents>)
-  implements GenericMediaManager
+  implements MediaManager
 {
   private constraints: MediaTrackConstraints | undefined;
   private storageConfig: StorageConfig | null;

--- a/packages/react-client/src/create.tsx
+++ b/packages/react-client/src/create.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { PeerState, Selector, State, UseReconnection } from "./state.types";
-import type { ScreenshareState, TrackManagerState } from "./types";
+import type { ScreenshareState } from "./types";
 import type { ConnectConfig, CreateConfig } from "@fishjam-cloud/ts-client";
 import type {
   DeviceManagerConfig,
@@ -194,12 +194,12 @@ export function create<PeerMetadata, TrackMetadata>(
     return useSelector((s) => s.client);
   }
 
-  function useCamera(): UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata> {
+  function useCamera(): UserMediaAPI & TrackManager<TrackMetadata> {
     const { state, videoTrackManager } = useFishjamContext();
     return { ...state.devices.camera, ...videoTrackManager };
   }
 
-  function useMicrophone(): UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata> {
+  function useMicrophone(): UserMediaAPI & TrackManager<TrackMetadata> {
     const { state, audioTrackManager } = useFishjamContext();
     return { ...state.devices.microphone, ...audioTrackManager };
   }

--- a/packages/react-client/src/create.tsx
+++ b/packages/react-client/src/create.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { PeerState, Selector, State, UseReconnection } from "./state.types";
-import type { ScreenshareState } from "./types";
+import type { ScreenshareState, TrackManagerState } from "./types";
 import type { ConnectConfig, CreateConfig } from "@fishjam-cloud/ts-client";
 import type {
   DeviceManagerConfig,
@@ -9,12 +9,13 @@ import type {
   FishjamContextType,
   FishjamContextProviderProps,
   UseConnect,
-  GenericTrackManager,
+  TrackManager,
   PeerStateWithTracks,
 } from "./types";
 import { Client } from "./Client";
 import { createUseSetupMediaHook } from "./useSetupMedia";
 import { useScreenShare as _useScreenShare } from "./screenShareTrackManager";
+import { useTrackManager } from "./trackManager";
 
 const eventNames = [
   "socketOpen",
@@ -114,8 +115,6 @@ export function create<PeerMetadata, TrackMetadata>(
           local: clientRef.current.local,
           status: clientRef.current.status,
           devices: clientRef.current.devices,
-          videoTrackManager: clientRef.current.videoTrackManager,
-          audioTrackManager: clientRef.current.audioTrackManager,
           client: clientRef.current,
           reconnectionStatus: clientRef.current.reconnectionStatus,
         } satisfies State<PeerMetadata, TrackMetadata>;
@@ -129,9 +128,25 @@ export function create<PeerMetadata, TrackMetadata>(
 
     const state = useSyncExternalStore(subscribe, getSnapshot);
 
+    const tsClient = state.client.getTsClient();
+
     const screenshareState = useState<ScreenshareState>(null);
 
-    return <FishjamContext.Provider value={{ state, screenshareState }}>{children}</FishjamContext.Provider>;
+    const videoTrackManager = useTrackManager({
+      mediaManager: state.client.videoDeviceManager,
+      tsClient,
+    });
+
+    const audioTrackManager = useTrackManager({
+      mediaManager: state.client.audioDeviceManager,
+      tsClient,
+    });
+
+    return (
+      <FishjamContext.Provider value={{ state, screenshareState, videoTrackManager, audioTrackManager }}>
+        {children}
+      </FishjamContext.Provider>
+    );
   }
 
   function useFishjamContext(): FishjamContextType<PeerMetadata, TrackMetadata> {
@@ -179,16 +194,14 @@ export function create<PeerMetadata, TrackMetadata>(
     return useSelector((s) => s.client);
   }
 
-  function useCamera(): UserMediaAPI<TrackMetadata> & GenericTrackManager<TrackMetadata> {
-    const { state } = useFishjamContext();
-
-    return { ...state.devices.camera, ...state.videoTrackManager };
+  function useCamera(): UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata> {
+    const { state, videoTrackManager } = useFishjamContext();
+    return { ...state.devices.camera, ...videoTrackManager };
   }
 
-  function useMicrophone(): UserMediaAPI<TrackMetadata> & GenericTrackManager<TrackMetadata> {
-    const { state } = useFishjamContext();
-
-    return { ...state.devices.microphone, ...state.audioTrackManager };
+  function useMicrophone(): UserMediaAPI<TrackMetadata> & TrackManager<TrackMetadata> {
+    const { state, audioTrackManager } = useFishjamContext();
+    return { ...state.devices.microphone, ...audioTrackManager };
   }
 
   function useReconnection(): UseReconnection {

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -26,7 +26,7 @@ export type {
   CreateFishjamClient,
   ScreenshareApi,
   UseConnect,
-  GenericTrackManager,
+  TrackManager,
   TrackMiddleware,
 } from "./types";
 

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ScreenshareApi,
   UseConnect,
   GenericTrackManager,
+  TrackMiddleware,
 } from "./types";
 
 export { AUDIO_TRACK_CONSTRAINTS, VIDEO_TRACK_CONSTRAINTS, SCREEN_SHARING_MEDIA_CONSTRAINTS } from "./constraints";

--- a/packages/react-client/src/screenShareTrackManager.ts
+++ b/packages/react-client/src/screenShareTrackManager.ts
@@ -54,12 +54,6 @@ export const useScreenShare = <PeerMetadata, TrackMetadata>(
     await replaceTracks(newVideoTrack, newAudioTrack);
   };
 
-  const removeTracksMiddleware = async (): Promise<void> => {
-    if (!state?.stream) return;
-    const [videoTrack, audioTrack] = getTracks(state.stream);
-    await replaceTracks(videoTrack, audioTrack);
-  };
-
   const stopStreaming: ScreenshareApi<TrackMetadata>["stopStreaming"] = useCallback(async () => {
     if (!state) {
       console.warn("No stream to stop");

--- a/packages/react-client/src/screenShareTrackManager.ts
+++ b/packages/react-client/src/screenShareTrackManager.ts
@@ -45,12 +45,8 @@ export const useScreenShare = <PeerMetadata, TrackMetadata>(
     if (!state?.stream) return;
 
     const [videoTrack, audioTrack] = getTracks(state.stream);
+    const [newVideoTrack, newAudioTrack] = middleware?.(videoTrack, audioTrack) ?? [videoTrack, audioTrack];
 
-    if (!middleware) {
-      return await replaceTracks(videoTrack, audioTrack);
-    }
-
-    const [newVideoTrack, newAudioTrack] = middleware(videoTrack, audioTrack);
     await replaceTracks(newVideoTrack, newAudioTrack);
   };
 

--- a/packages/react-client/src/screenShareTrackManager.ts
+++ b/packages/react-client/src/screenShareTrackManager.ts
@@ -1,13 +1,13 @@
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import { useCallback, useEffect } from "react";
 import { getRemoteOrLocalTrack } from "./utils/track";
-import type { ScreenshareApi, ScreenshareState } from "./types";
+import type { ScreenshareApi, ScreenshareState, TracksMiddleware } from "./types";
 
-const getTracks = (stream: MediaStream): { video: MediaStreamTrack; audio: MediaStreamTrack | null } => {
+const getTracks = (stream: MediaStream): [MediaStreamTrack, MediaStreamTrack | null] => {
   const video = stream.getVideoTracks()[0];
   const audio = stream.getAudioTracks()[0] ?? null;
 
-  return { video, audio };
+  return [video, audio];
 };
 
 export const useScreenShare = <PeerMetadata, TrackMetadata>(
@@ -20,13 +20,38 @@ export const useScreenShare = <PeerMetadata, TrackMetadata>(
       video: props?.videoConstraints ?? true,
       audio: props?.audioConstraints ?? true,
     });
-    const { video, audio } = getTracks(stream);
+    const [video, audio] = getTracks(stream);
 
     const addTrackPromises = [tsClient.addTrack(video, props?.metadata)];
     if (audio) addTrackPromises.push(tsClient.addTrack(audio, props?.metadata));
 
     const [videoId, audioId] = await Promise.all(addTrackPromises);
     setState({ stream, trackIds: { videoId, audioId } });
+  };
+
+  const replaceTracks = async (newVideoTrack: MediaStreamTrack, newAudioTrack: MediaStreamTrack | null) => {
+    if (!state?.stream) return;
+
+    const addTrackPromises = [tsClient.replaceTrack(state.trackIds.videoId, newVideoTrack)];
+
+    if (newAudioTrack && state.trackIds.audioId) {
+      addTrackPromises.push(tsClient.replaceTrack(state.trackIds.audioId, newAudioTrack));
+    }
+
+    await Promise.all(addTrackPromises);
+  };
+
+  const modifyTracks = async (middleware?: TracksMiddleware): Promise<void> => {
+    if (!state?.stream) return;
+
+    const [videoTrack, audioTrack] = getTracks(state.stream);
+
+    if (!middleware) {
+      return await replaceTracks(videoTrack, audioTrack);
+    }
+
+    const [newVideoTrack, newAudioTrack] = middleware(videoTrack, audioTrack);
+    await replaceTracks(newVideoTrack, newAudioTrack);
   };
 
   const stopStreaming: ScreenshareApi<TrackMetadata>["stopStreaming"] = useCallback(async () => {
@@ -78,9 +103,6 @@ export const useScreenShare = <PeerMetadata, TrackMetadata>(
   const stream = state?.stream ?? null;
   const tracks = stream ? getTracks(stream) : { video: null, audio: null };
 
-  const videoTrack = tracks.video;
-  const audioTrack = tracks.audio;
-
   const videoBroadcast = state ? getRemoteOrLocalTrack(tsClient, state.trackIds.videoId) : null;
   const audioBroadcast = state?.trackIds.audioId ? getRemoteOrLocalTrack(tsClient, state.trackIds.audioId) : null;
 
@@ -88,8 +110,8 @@ export const useScreenShare = <PeerMetadata, TrackMetadata>(
     startStreaming,
     stopStreaming,
     stream,
-    videoTrack,
-    audioTrack,
+    videoTrack: tracks.video,
+    audioTrack: tracks.audio,
     videoBroadcast,
     audioBroadcast,
   };

--- a/packages/react-client/src/screenShareTrackManager.ts
+++ b/packages/react-client/src/screenShareTrackManager.ts
@@ -121,5 +121,6 @@ export const useScreenShare = <PeerMetadata, TrackMetadata>(
     videoBroadcast,
     audioBroadcast,
     setTracksMiddleware,
+    currentTracksMiddleware: state?.tracksMiddleware ?? null,
   };
 };

--- a/packages/react-client/src/state.types.ts
+++ b/packages/react-client/src/state.types.ts
@@ -2,7 +2,6 @@ import type { Encoding, VadStatus, SimulcastConfig, ReconnectionStatus } from "@
 import type { MediaState } from "./types";
 import type { Devices } from "./types";
 import type { Client } from "./Client";
-import type { TrackManager } from "./trackManager";
 
 export type TrackId = string;
 export type PeerId = string;
@@ -57,8 +56,6 @@ export type State<PeerMetadata, TrackMetadata> = {
   media: MediaState | null;
   devices: Devices<TrackMetadata>;
   client: Client<PeerMetadata, TrackMetadata>;
-  videoTrackManager: TrackManager<PeerMetadata, TrackMetadata>;
-  audioTrackManager: TrackManager<PeerMetadata, TrackMetadata>;
   reconnectionStatus: ReconnectionStatus;
 };
 

--- a/packages/react-client/src/state.types.ts
+++ b/packages/react-client/src/state.types.ts
@@ -54,7 +54,7 @@ export type State<PeerMetadata, TrackMetadata> = {
   bandwidthEstimation: bigint;
   status: PeerStatus;
   media: MediaState | null;
-  devices: Devices<TrackMetadata>;
+  devices: Devices;
   client: Client<PeerMetadata, TrackMetadata>;
   reconnectionStatus: ReconnectionStatus;
 };

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -28,9 +28,8 @@ export class TrackManager<PeerMetadata, TrackMetadata> implements GenericTrackMa
     middleware: ((track: MediaStreamTrack) => MediaStreamTrack) | null,
   ): Promise<void> => {
     if (middleware === this.currentTrackMiddleware) return;
-
     const currentTrack = this.getCurrentTrack();
-    const mediaTrack = this.mediaManager.getTracks().find((track) => track.id === this.currentTrackId);
+    const mediaTrack = this.mediaManager.getTracks()[0];
 
     if (!currentTrack || !mediaTrack) return;
 

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -107,14 +107,6 @@ export const useTrackManager = <PeerMetadata, TrackMetadata>({
     await tsClient.replaceTrack(prevTrack.trackId, null);
   };
 
-  const isMuted = () => {
-    const media = mediaManager.getMedia();
-    const isTrackDisabled = !media?.track?.enabled;
-    const areMediaDisabled = !media?.enabled;
-
-    return isTrackDisabled && areMediaDisabled;
-  };
-
   const resumeStreaming = async () => {
     const prevTrack = getPreviousTrack();
     const media = mediaManager.getMedia();

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -62,11 +62,11 @@ export const useTrackManager = <PeerMetadata, TrackMetadata>({
     mediaManager?.stop();
   }
 
-  const startStreaming = async (
+  async function startStreaming(
     trackMetadata?: TrackMetadata,
     simulcastConfig?: SimulcastConfig,
     maxBandwidth?: TrackBandwidthLimit,
-  ) => {
+  ) {
     if (currentTrackId) throw Error("Track already added");
 
     const media = mediaManager.getMedia();
@@ -85,44 +85,44 @@ export const useTrackManager = <PeerMetadata, TrackMetadata>({
     setCurrentTrackId(remoteTrackId);
 
     return remoteTrackId;
-  };
+  }
 
-  const refreshStreamedTrack = async () => {
+  async function refreshStreamedTrack() {
     const prevTrack = getPreviousTrack();
 
     const newTrack = mediaManager.getTracks()[0];
     if (!newTrack) throw Error("New track is empty");
 
     return tsClient.replaceTrack(prevTrack.trackId, newTrack);
-  };
+  }
 
-  const stopStreaming = async () => {
+  function stopStreaming() {
     const prevTrack = getPreviousTrack();
     setCurrentTrackId(null);
     return tsClient.removeTrack(prevTrack.trackId);
-  };
+  }
 
-  const pauseStreaming = async () => {
+  function pauseStreaming() {
     const prevTrack = getPreviousTrack();
-    await tsClient.replaceTrack(prevTrack.trackId, null);
-  };
+    return tsClient.replaceTrack(prevTrack.trackId, null);
+  }
 
-  const resumeStreaming = async () => {
+  function resumeStreaming() {
     const prevTrack = getPreviousTrack();
     const media = mediaManager.getMedia();
 
     if (!media) throw Error("Device is unavailable");
 
-    await tsClient.replaceTrack(prevTrack.trackId, media.track);
-  };
+    return tsClient.replaceTrack(prevTrack.trackId, media.track);
+  }
 
-  const disableTrack = async () => {
-    mediaManager.disable();
-  };
+  function disableTrack() {
+    return mediaManager.disable();
+  }
 
-  const enableTrack = async () => {
-    mediaManager.enable();
-  };
+  function enableTrack() {
+    return mediaManager.enable();
+  }
 
   return {
     getCurrentTrack,

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -1,128 +1,149 @@
 import type { FishjamClient, SimulcastConfig, TrackBandwidthLimit } from "@fishjam-cloud/ts-client";
-import type { GenericMediaManager, GenericTrackManager } from "./types";
+import type { MediaManager, TrackManager, TrackMiddleware } from "./types";
 import type { Track } from "./state.types";
 import { getRemoteOrLocalTrack } from "./utils/track";
+import { useEffect, useState } from "react";
 
-export class TrackManager<PeerMetadata, TrackMetadata> implements GenericTrackManager<TrackMetadata> {
-  private readonly mediaManager: GenericMediaManager;
-  private readonly tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
-  private currentTrackId: string | null = null;
-  public currentTrackMiddleware: ((track: MediaStreamTrack) => MediaStreamTrack) | null = null;
+interface TrackManagerConfig<PeerMetadata, TrackMetadata> {
+  mediaManager: MediaManager;
+  tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
+}
 
-  constructor(tsClient: FishjamClient<PeerMetadata, TrackMetadata>, deviceManager: GenericMediaManager) {
-    this.mediaManager = deviceManager;
-    this.tsClient = tsClient;
-  }
+export const useTrackManager = <PeerMetadata, TrackMetadata>({
+  mediaManager,
+  tsClient,
+}: TrackManagerConfig<PeerMetadata, TrackMetadata>): TrackManager<TrackMetadata> => {
+  const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
+  const [currentTrackMiddleware, setCurrentTrackMiddleware] = useState<TrackMiddleware>(null);
 
-  private getPreviousTrack = (): Track<TrackMetadata> => {
-    if (!this.currentTrackId) throw Error("There is no current track id");
+  useEffect(() => {
+    const disconnectedHandler = () => {
+      setCurrentTrackId(null);
+    };
 
-    const prevTrack = getRemoteOrLocalTrack<PeerMetadata, TrackMetadata>(this.tsClient, this.currentTrackId);
+    tsClient.on("disconnected", disconnectedHandler);
+
+    return () => {
+      tsClient.off("disconnected", disconnectedHandler);
+    };
+  }, [tsClient]);
+
+  function getPreviousTrack(): Track<TrackMetadata> {
+    if (!currentTrackId) throw Error("There is no current track id");
+
+    const prevTrack = getRemoteOrLocalTrack<PeerMetadata, TrackMetadata>(tsClient, currentTrackId);
 
     if (!prevTrack) throw Error("There is no previous track");
 
     return prevTrack;
-  };
+  }
 
-  public setTrackMiddleware = async (
-    middleware: ((track: MediaStreamTrack) => MediaStreamTrack) | null,
-  ): Promise<void> => {
-    if (middleware === this.currentTrackMiddleware) return;
-    const currentTrack = this.getCurrentTrack();
-    const mediaTrack = this.mediaManager.getTracks()[0];
+  async function setTrackMiddleware(middleware: TrackMiddleware): Promise<void> {
+    const currentTrack = getCurrentTrack();
+    const mediaTrack = mediaManager.getTracks()[0];
 
     if (!currentTrack || !mediaTrack) return;
 
     const trackToSet = middleware ? middleware(mediaTrack) : mediaTrack;
+    await tsClient.replaceTrack(currentTrack.trackId, trackToSet);
 
-    await this.tsClient.replaceTrack(currentTrack.trackId, trackToSet);
+    setCurrentTrackMiddleware(() => middleware);
+  }
 
-    this.currentTrackMiddleware = middleware;
-  };
+  function getCurrentTrack(): Track<TrackMetadata> | null {
+    return getRemoteOrLocalTrack<PeerMetadata, TrackMetadata>(tsClient, currentTrackId);
+  }
 
-  public getCurrentTrack = (): Track<TrackMetadata> | null => {
-    return getRemoteOrLocalTrack<PeerMetadata, TrackMetadata>(this.tsClient, this.currentTrackId);
-  };
+  async function initialize(deviceId?: string) {
+    mediaManager?.start(deviceId ?? true);
+  }
 
-  public initialize = async (deviceId?: string) => {
-    this.mediaManager?.start(deviceId ?? true);
-  };
+  async function stop() {
+    mediaManager?.stop();
+  }
 
-  public stop = async () => {
-    this?.mediaManager?.stop();
-  };
-
-  public cleanup = () => {
-    this.currentTrackId = null;
-  };
-
-  public startStreaming = async (
+  const startStreaming = async (
     trackMetadata?: TrackMetadata,
     simulcastConfig?: SimulcastConfig,
     maxBandwidth?: TrackBandwidthLimit,
   ) => {
-    if (this.currentTrackId) throw Error("Track already added");
+    if (currentTrackId) throw Error("Track already added");
 
-    const media = this.mediaManager.getMedia();
+    const media = mediaManager.getMedia();
 
     if (!media || !media.stream || !media.track) throw Error("Device is unavailable");
 
-    const track = getRemoteOrLocalTrack(this.tsClient, this.currentTrackId);
+    const track = getRemoteOrLocalTrack(tsClient, currentTrackId);
 
     if (track) return track.trackId;
 
     // see `getRemoteOrLocalTrackContext()` explanation
-    this.currentTrackId = media.track.id;
+    setCurrentTrackId(media.track.id);
 
-    const remoteTrackId = await this.tsClient.addTrack(media.track, trackMetadata, simulcastConfig, maxBandwidth);
+    const remoteTrackId = await tsClient.addTrack(media.track, trackMetadata, simulcastConfig, maxBandwidth);
 
-    this.currentTrackId = remoteTrackId;
+    setCurrentTrackId(remoteTrackId);
 
     return remoteTrackId;
   };
 
-  public refreshStreamedTrack = async () => {
-    const prevTrack = this.getPreviousTrack();
+  const refreshStreamedTrack = async () => {
+    const prevTrack = getPreviousTrack();
 
-    const newTrack = this.mediaManager.getTracks()[0];
+    const newTrack = mediaManager.getTracks()[0];
     if (!newTrack) throw Error("New track is empty");
 
-    return this.tsClient.replaceTrack(prevTrack.trackId, newTrack);
+    return tsClient.replaceTrack(prevTrack.trackId, newTrack);
   };
 
-  public stopStreaming = async () => {
-    const prevTrack = this.getPreviousTrack();
-    this.currentTrackId = null;
-    return this.tsClient.removeTrack(prevTrack.trackId);
+  const stopStreaming = async () => {
+    const prevTrack = getPreviousTrack();
+    setCurrentTrackId(null);
+    return tsClient.removeTrack(prevTrack.trackId);
   };
 
-  public pauseStreaming = async () => {
-    const prevTrack = this.getPreviousTrack();
-    await this.tsClient.replaceTrack(prevTrack.trackId, null);
+  const pauseStreaming = async () => {
+    const prevTrack = getPreviousTrack();
+    await tsClient.replaceTrack(prevTrack.trackId, null);
   };
 
-  public isMuted = () => {
-    const media = this.mediaManager.getMedia();
+  const isMuted = () => {
+    const media = mediaManager.getMedia();
     const isTrackDisabled = !media?.track?.enabled;
     const areMediaDisabled = !media?.enabled;
 
     return isTrackDisabled && areMediaDisabled;
   };
 
-  public resumeStreaming = async () => {
-    const prevTrack = this.getPreviousTrack();
-    const media = this.mediaManager.getMedia();
+  const resumeStreaming = async () => {
+    const prevTrack = getPreviousTrack();
+    const media = mediaManager.getMedia();
 
     if (!media) throw Error("Device is unavailable");
 
-    await this.tsClient.replaceTrack(prevTrack.trackId, media.track);
+    await tsClient.replaceTrack(prevTrack.trackId, media.track);
   };
 
-  public disableTrack = async () => {
-    this.mediaManager.disable();
+  const disableTrack = async () => {
+    mediaManager.disable();
   };
 
-  public enableTrack = async () => {
-    this.mediaManager.enable();
+  const enableTrack = async () => {
+    mediaManager.enable();
   };
-}
+
+  return {
+    getCurrentTrack,
+    setTrackMiddleware,
+    initialize,
+    stop,
+    startStreaming,
+    stopStreaming,
+    pauseStreaming,
+    resumeStreaming,
+    disableTrack,
+    enableTrack,
+    currentTrackMiddleware,
+    refreshStreamedTrack,
+  };
+};

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -153,6 +153,8 @@ export interface GenericMediaManager {
   getMedia: () => { stream: MediaStream | null; track: MediaStreamTrack | null; enabled: boolean } | null;
 }
 
+export type TrackMiddleware = ((track: MediaStreamTrack) => MediaStreamTrack) | null;
+
 export interface GenericTrackManager<TrackMetadata> {
   initialize: (deviceId?: string) => Promise<void>;
   stop: () => Promise<void>;
@@ -166,6 +168,7 @@ export interface GenericTrackManager<TrackMetadata> {
   resumeStreaming: () => Promise<void>;
   disableTrack: () => void;
   enableTrack: () => void;
+  setTrackMiddleware: (middleware: TrackMiddleware) => Promise<void>;
 }
 
 export type UserMediaAPI<TrackMetadata> = {
@@ -192,6 +195,7 @@ export type ScreenshareApi<TrackMetadata> = {
   audioTrack: MediaStreamTrack | null;
   videoBroadcast: Track<TrackMetadata> | null;
   audioBroadcast: Track<TrackMetadata> | null;
+  setTracksMiddleware: (middleware: TracksMiddleware | null) => Promise<void>;
 };
 
 export type Devices<TrackMetadata> = {

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -180,7 +180,7 @@ export interface TrackManager<TrackMetadata> {
   getCurrentTrack: () => Track<TrackMetadata> | null;
 }
 
-export type UserMediaAPI<TrackMetadata> = {
+export type UserMediaAPI = {
   status: DevicesStatus | null; // todo how to remove null
   stream: MediaStream | null;
   track: MediaStreamTrack | null;
@@ -212,9 +212,9 @@ export type ScreenshareApi<TrackMetadata> = {
   currentTracksMiddleware: TracksMiddleware | null;
 };
 
-export type Devices<TrackMetadata> = {
-  camera: UserMediaAPI<TrackMetadata>;
-  microphone: UserMediaAPI<TrackMetadata>;
+export type Devices = {
+  camera: UserMediaAPI;
+  microphone: UserMediaAPI;
 };
 
 export type FishjamContextProviderProps = {
@@ -251,8 +251,8 @@ export type CreateFishjamClient<PeerMetadata, TrackMetadata> = {
   useSelector: <Result>(selector: Selector<PeerMetadata, TrackMetadata, Result>) => Result;
   useTracks: () => Record<TrackId, TrackWithOrigin<PeerMetadata, TrackMetadata>>;
   useSetupMedia: (config: UseSetupMediaConfig<TrackMetadata>) => UseSetupMediaResult;
-  useCamera: () => Devices<TrackMetadata>["camera"] & TrackManager<TrackMetadata>;
-  useMicrophone: () => Devices<TrackMetadata>["microphone"] & TrackManager<TrackMetadata>;
+  useCamera: () => Devices["camera"] & TrackManager<TrackMetadata>;
+  useMicrophone: () => Devices["microphone"] & TrackManager<TrackMetadata>;
   useClient: () => Client<PeerMetadata, TrackMetadata>;
   useReconnection: () => UseReconnection;
   useParticipants: () => {

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -155,6 +155,12 @@ export interface GenericMediaManager {
 
 export type TrackMiddleware = ((track: MediaStreamTrack) => MediaStreamTrack) | null;
 
+export type ScreenshareState = {
+  stream: MediaStream;
+  trackIds: { videoId: string; audioId?: string };
+  tracksMiddleware?: TracksMiddleware | null;
+} | null;
+
 export interface GenericTrackManager<TrackMetadata> {
   initialize: (deviceId?: string) => Promise<void>;
   stop: () => Promise<void>;
@@ -169,6 +175,7 @@ export interface GenericTrackManager<TrackMetadata> {
   disableTrack: () => void;
   enableTrack: () => void;
   setTrackMiddleware: (middleware: TrackMiddleware) => Promise<void>;
+  currentTrackMiddleware: TrackMiddleware;
 }
 
 export type UserMediaAPI<TrackMetadata> = {
@@ -196,6 +203,7 @@ export type ScreenshareApi<TrackMetadata> = {
   videoBroadcast: Track<TrackMetadata> | null;
   audioBroadcast: Track<TrackMetadata> | null;
   setTracksMiddleware: (middleware: TracksMiddleware | null) => Promise<void>;
+  currentTracksMiddleware: TracksMiddleware | null;
 };
 
 export type Devices<TrackMetadata> = {
@@ -211,12 +219,6 @@ export type TracksMiddleware = (
   videoTrack: MediaStreamTrack,
   audioTrack: MediaStreamTrack | null,
 ) => [MediaStreamTrack, MediaStreamTrack | null];
-
-export type ScreenshareState = {
-  stream: MediaStream;
-  trackIds: { videoId: string; audioId?: string };
-  tracksMiddleware?: TracksMiddleware | null;
-} | null;
 
 export type FishjamContextType<PeerMetadata, TrackMetadata> = {
   state: State<PeerMetadata, TrackMetadata>;

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -203,9 +203,15 @@ export type FishjamContextProviderProps = {
   children: ReactNode;
 };
 
+export type TracksMiddleware = (
+  videoTrack: MediaStreamTrack,
+  audioTrack: MediaStreamTrack | null,
+) => [MediaStreamTrack, MediaStreamTrack | null];
+
 export type ScreenshareState = {
   stream: MediaStream;
   trackIds: { videoId: string; audioId?: string };
+  tracksMiddleware?: TracksMiddleware | null;
 } | null;
 
 export type FishjamContextType<PeerMetadata, TrackMetadata> = {

--- a/packages/react-client/src/useSetupMedia.ts
+++ b/packages/react-client/src/useSetupMedia.ts
@@ -129,7 +129,7 @@ export const createUseSetupMediaHook = <PeerMetadata, TrackMetadata>(
       return () => {
         state.client.removeListener("deviceStopped", removeOnCameraStopped);
       };
-    }, [state.client]);
+    }, [state.client, videoTrackManager]);
 
     useEffect(() => {
       const broadcastCameraOnConnect: ClientEvents<PeerMetadata, TrackMetadata>["joined"] = async (_, client) => {
@@ -151,7 +151,7 @@ export const createUseSetupMediaHook = <PeerMetadata, TrackMetadata>(
       return () => {
         state.client.removeListener("joined", broadcastCameraOnConnect);
       };
-    }, [state.client]);
+    }, [state.client, videoTrackManager]);
 
     useEffect(() => {
       let pending = false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -32,86 +32,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/compat-data@npm:^7.24.8":
-  version: 7.24.9
-  resolution: "@babel/compat-data@npm:7.24.9"
-  checksum: 10c0/95a69c9ed00ae78b4921f33403e9b35518e6139a0c46af763c65dea160720cb57c6cc23f7d30249091a0248335b0e39de5c8dfa8e7877c830e44561e0bdc1254
+"@babel/compat-data@npm:^7.25.2":
+  version: 7.25.4
+  resolution: "@babel/compat-data@npm:7.25.4"
+  checksum: 10c0/50d79734d584a28c69d6f5b99adfaa064d0f41609a378aef04eb06accc5b44f8520e68549eba3a082478180957b7d5783f1bfb1672e4ae8574e797ce8bae79fa
   languageName: node
   linkType: hard
 
 "@babel/core@npm:^7.24.5":
-  version: 7.24.9
-  resolution: "@babel/core@npm:7.24.9"
+  version: 7.25.2
+  resolution: "@babel/core@npm:7.25.2"
   dependencies:
     "@ampproject/remapping": "npm:^2.2.0"
     "@babel/code-frame": "npm:^7.24.7"
-    "@babel/generator": "npm:^7.24.9"
-    "@babel/helper-compilation-targets": "npm:^7.24.8"
-    "@babel/helper-module-transforms": "npm:^7.24.9"
-    "@babel/helpers": "npm:^7.24.8"
-    "@babel/parser": "npm:^7.24.8"
-    "@babel/template": "npm:^7.24.7"
-    "@babel/traverse": "npm:^7.24.8"
-    "@babel/types": "npm:^7.24.9"
+    "@babel/generator": "npm:^7.25.0"
+    "@babel/helper-compilation-targets": "npm:^7.25.2"
+    "@babel/helper-module-transforms": "npm:^7.25.2"
+    "@babel/helpers": "npm:^7.25.0"
+    "@babel/parser": "npm:^7.25.0"
+    "@babel/template": "npm:^7.25.0"
+    "@babel/traverse": "npm:^7.25.2"
+    "@babel/types": "npm:^7.25.2"
     convert-source-map: "npm:^2.0.0"
     debug: "npm:^4.1.0"
     gensync: "npm:^1.0.0-beta.2"
     json5: "npm:^2.2.3"
     semver: "npm:^6.3.1"
-  checksum: 10c0/e104ec6efbf099f55184933e9ab078eb5821c792ddfef3e9c6561986ec4ff103f5c11e3d7d6e5e8929e50e2c58db1cc80e5b6f14b530335b6622095ec4b4124c
+  checksum: 10c0/a425fa40e73cb72b6464063a57c478bc2de9dbcc19c280f1b55a3d88b35d572e87e8594e7d7b4880331addb6faef641bbeb701b91b41b8806cd4deae5d74f401
   languageName: node
   linkType: hard
 
-"@babel/generator@npm:^7.24.8, @babel/generator@npm:^7.24.9":
-  version: 7.24.10
-  resolution: "@babel/generator@npm:7.24.10"
+"@babel/generator@npm:^7.25.0, @babel/generator@npm:^7.25.4":
+  version: 7.25.4
+  resolution: "@babel/generator@npm:7.25.4"
   dependencies:
-    "@babel/types": "npm:^7.24.9"
+    "@babel/types": "npm:^7.25.4"
     "@jridgewell/gen-mapping": "npm:^0.3.5"
     "@jridgewell/trace-mapping": "npm:^0.3.25"
     jsesc: "npm:^2.5.1"
-  checksum: 10c0/abcfd75f625aecc87ce6036ef788b12723fd3c46530df1130d1f00d18e48b462849ddaeef8b1a02bfdcb6e28956389a98c5729dad1c3c5448307dacb6c959f29
+  checksum: 10c0/a2d8cc39e759214740f836360c8d9c17aa93e16e41afe73368a9e7ccd1d5c3303a420ce3aca1c9a31fdb93d1899de471d5aac97d1c64f741f8750a25a6e91fbc
   languageName: node
   linkType: hard
 
-"@babel/helper-compilation-targets@npm:^7.24.8":
-  version: 7.24.8
-  resolution: "@babel/helper-compilation-targets@npm:7.24.8"
+"@babel/helper-compilation-targets@npm:^7.25.2":
+  version: 7.25.2
+  resolution: "@babel/helper-compilation-targets@npm:7.25.2"
   dependencies:
-    "@babel/compat-data": "npm:^7.24.8"
+    "@babel/compat-data": "npm:^7.25.2"
     "@babel/helper-validator-option": "npm:^7.24.8"
     browserslist: "npm:^4.23.1"
     lru-cache: "npm:^5.1.1"
     semver: "npm:^6.3.1"
-  checksum: 10c0/2885c44ef6aaf82b7e4352b30089bb09fbe08ed5ec24eb452c2bdc3c021e2a65ab412f74b3d67ec1398da0356c730b33a2ceca1d67d34c85080d31ca6efa9aec
-  languageName: node
-  linkType: hard
-
-"@babel/helper-environment-visitor@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/helper-environment-visitor@npm:7.24.7"
-  dependencies:
-    "@babel/types": "npm:^7.24.7"
-  checksum: 10c0/36ece78882b5960e2d26abf13cf15ff5689bf7c325b10a2895a74a499e712de0d305f8d78bb382dd3c05cfba7e47ec98fe28aab5674243e0625cd38438dd0b2d
-  languageName: node
-  linkType: hard
-
-"@babel/helper-function-name@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/helper-function-name@npm:7.24.7"
-  dependencies:
-    "@babel/template": "npm:^7.24.7"
-    "@babel/types": "npm:^7.24.7"
-  checksum: 10c0/e5e41e6cf86bd0f8bf272cbb6e7c5ee0f3e9660414174435a46653efba4f2479ce03ce04abff2aa2ef9359cf057c79c06cb7b134a565ad9c0e8a50dcdc3b43c4
-  languageName: node
-  linkType: hard
-
-"@babel/helper-hoist-variables@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/helper-hoist-variables@npm:7.24.7"
-  dependencies:
-    "@babel/types": "npm:^7.24.7"
-  checksum: 10c0/19ee37563bbd1219f9d98991ad0e9abef77803ee5945fd85aa7aa62a67c69efca9a801696a1b58dda27f211e878b3327789e6fd2a6f6c725ccefe36774b5ce95
+  checksum: 10c0/de10e986b5322c9f807350467dc845ec59df9e596a5926a3b5edbb4710d8e3b8009d4396690e70b88c3844fe8ec4042d61436dd4b92d1f5f75655cf43ab07e99
   languageName: node
   linkType: hard
 
@@ -125,18 +97,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helper-module-transforms@npm:^7.24.9":
-  version: 7.24.9
-  resolution: "@babel/helper-module-transforms@npm:7.24.9"
+"@babel/helper-module-transforms@npm:^7.25.2":
+  version: 7.25.2
+  resolution: "@babel/helper-module-transforms@npm:7.25.2"
   dependencies:
-    "@babel/helper-environment-visitor": "npm:^7.24.7"
     "@babel/helper-module-imports": "npm:^7.24.7"
     "@babel/helper-simple-access": "npm:^7.24.7"
-    "@babel/helper-split-export-declaration": "npm:^7.24.7"
     "@babel/helper-validator-identifier": "npm:^7.24.7"
+    "@babel/traverse": "npm:^7.25.2"
   peerDependencies:
     "@babel/core": ^7.0.0
-  checksum: 10c0/e27bca43bc113731ee4f2b33a4c5bf9c7eebf4d64487b814c305cbd5feb272c29fcd3d79634ba03131ade171e5972bc7ede8dbc83ba0deb02f1e62d318c87770
+  checksum: 10c0/adaa15970ace0aee5934b5a633789b5795b6229c6a9cf3e09a7e80aa33e478675eee807006a862aa9aa517935d81f88a6db8a9f5936e3a2a40ec75f8062bc329
   languageName: node
   linkType: hard
 
@@ -154,15 +125,6 @@ __metadata:
     "@babel/traverse": "npm:^7.24.7"
     "@babel/types": "npm:^7.24.7"
   checksum: 10c0/7230e419d59a85f93153415100a5faff23c133d7442c19e0cd070da1784d13cd29096ee6c5a5761065c44e8164f9f80e3a518c41a0256df39e38f7ad6744fed7
-  languageName: node
-  linkType: hard
-
-"@babel/helper-split-export-declaration@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/helper-split-export-declaration@npm:7.24.7"
-  dependencies:
-    "@babel/types": "npm:^7.24.7"
-  checksum: 10c0/0254577d7086bf09b01bbde98f731d4fcf4b7c3fa9634fdb87929801307c1f6202a1352e3faa5492450fa8da4420542d44de604daf540704ff349594a78184f6
   languageName: node
   linkType: hard
 
@@ -187,13 +149,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/helpers@npm:^7.24.8":
-  version: 7.24.8
-  resolution: "@babel/helpers@npm:7.24.8"
+"@babel/helpers@npm:^7.25.0":
+  version: 7.25.0
+  resolution: "@babel/helpers@npm:7.25.0"
   dependencies:
-    "@babel/template": "npm:^7.24.7"
-    "@babel/types": "npm:^7.24.8"
-  checksum: 10c0/42b8939b0a0bf72d6df9721973eb0fd7cd48f42641c5c9c740916397faa586255c06d36c6e6a7e091860723096281c620f6ffaee0011a3bb254a6f5475d89a12
+    "@babel/template": "npm:^7.25.0"
+    "@babel/types": "npm:^7.25.0"
+  checksum: 10c0/b7fe007fc4194268abf70aa3810365085e290e6528dcb9fbbf7a765d43c74b6369ce0f99c5ccd2d44c413853099daa449c9a0123f0b212ac8d18643f2e8174b8
   languageName: node
   linkType: hard
 
@@ -209,12 +171,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.24.7, @babel/parser@npm:^7.24.8":
-  version: 7.24.8
-  resolution: "@babel/parser@npm:7.24.8"
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.25.0, @babel/parser@npm:^7.25.4":
+  version: 7.25.4
+  resolution: "@babel/parser@npm:7.25.4"
+  dependencies:
+    "@babel/types": "npm:^7.25.4"
   bin:
     parser: ./bin/babel-parser.js
-  checksum: 10c0/ce69671de8fa6f649abf849be262707ac700b573b8b1ce1893c66cc6cd76aeb1294a19e8c290b0eadeb2f47d3f413a2e57a281804ffbe76bfb9fa50194cf3c52
+  checksum: 10c0/bdada5662f15d1df11a7266ec3bc9bb769bf3637ecf3d051eafcfc8f576dcf5a3ac1007c5e059db4a1e1387db9ae9caad239fc4f79e4c2200930ed610e779993
   languageName: node
   linkType: hard
 
@@ -240,43 +204,40 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/template@npm:^7.24.7":
-  version: 7.24.7
-  resolution: "@babel/template@npm:7.24.7"
+"@babel/template@npm:^7.25.0":
+  version: 7.25.0
+  resolution: "@babel/template@npm:7.25.0"
   dependencies:
     "@babel/code-frame": "npm:^7.24.7"
-    "@babel/parser": "npm:^7.24.7"
-    "@babel/types": "npm:^7.24.7"
-  checksum: 10c0/95b0b3ee80fcef685b7f4426f5713a855ea2cd5ac4da829b213f8fb5afe48a2a14683c2ea04d446dbc7f711c33c5cd4a965ef34dcbe5bc387c9e966b67877ae3
+    "@babel/parser": "npm:^7.25.0"
+    "@babel/types": "npm:^7.25.0"
+  checksum: 10c0/4e31afd873215744c016e02b04f43b9fa23205d6d0766fb2e93eb4091c60c1b88897936adb895fb04e3c23de98dfdcbe31bc98daaa1a4e0133f78bb948e1209b
   languageName: node
   linkType: hard
 
-"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.24.8":
-  version: 7.24.8
-  resolution: "@babel/traverse@npm:7.24.8"
+"@babel/traverse@npm:^7.24.7, @babel/traverse@npm:^7.25.2":
+  version: 7.25.4
+  resolution: "@babel/traverse@npm:7.25.4"
   dependencies:
     "@babel/code-frame": "npm:^7.24.7"
-    "@babel/generator": "npm:^7.24.8"
-    "@babel/helper-environment-visitor": "npm:^7.24.7"
-    "@babel/helper-function-name": "npm:^7.24.7"
-    "@babel/helper-hoist-variables": "npm:^7.24.7"
-    "@babel/helper-split-export-declaration": "npm:^7.24.7"
-    "@babel/parser": "npm:^7.24.8"
-    "@babel/types": "npm:^7.24.8"
+    "@babel/generator": "npm:^7.25.4"
+    "@babel/parser": "npm:^7.25.4"
+    "@babel/template": "npm:^7.25.0"
+    "@babel/types": "npm:^7.25.4"
     debug: "npm:^4.3.1"
     globals: "npm:^11.1.0"
-  checksum: 10c0/67a5cc35824455cdb54fb9e196a44b3186283e29018a9c2331f51763921e18e891b3c60c283615a27540ec8eb4c8b89f41c237b91f732a7aa518b2eb7a0d434d
+  checksum: 10c0/37c9b49b277e051fe499ef5f6f217370c4f648d6370564d70b5e6beb2da75bfda6d7dab1d39504d89e9245448f8959bc1a5880d2238840cdc3979b35338ed0f5
   languageName: node
   linkType: hard
 
-"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.7, @babel/types@npm:^7.24.8, @babel/types@npm:^7.24.9, @babel/types@npm:^7.8.3":
-  version: 7.24.9
-  resolution: "@babel/types@npm:7.24.9"
+"@babel/types@npm:^7.0.0, @babel/types@npm:^7.20.7, @babel/types@npm:^7.24.0, @babel/types@npm:^7.24.7, @babel/types@npm:^7.25.0, @babel/types@npm:^7.25.2, @babel/types@npm:^7.25.4":
+  version: 7.25.4
+  resolution: "@babel/types@npm:7.25.4"
   dependencies:
     "@babel/helper-string-parser": "npm:^7.24.8"
     "@babel/helper-validator-identifier": "npm:^7.24.7"
     to-fast-properties: "npm:^2.0.0"
-  checksum: 10c0/4970b3481cab39c5c3fdb7c28c834df5c7049f3c7f43baeafe121bb05270ebf0da7c65b097abf314877f213baa591109c82204f30d66cdd46c22ece4a2f32415
+  checksum: 10c0/9aa25dfcd89cc4e4dde3188091c34398a005a49e2c2b069d0367b41e1122c91e80fd92998c52a90f2fb500f7e897b6090ec8be263d9cb53d0d75c756f44419f2
   languageName: node
   linkType: hard
 
@@ -711,7 +672,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.4.15":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.0":
   version: 1.5.0
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.0"
   checksum: 10c0/2eb864f276eb1096c3c11da3e9bb518f6d9fc0023c78344cdc037abadc725172c70314bdb360f2d4b7bffec7f5d657ce006816bc5d4ecb35e61b66132db00c18
@@ -732,6 +693,13 @@ __metadata:
   version: 0.2.7
   resolution: "@material/material-color-utilities@npm:0.2.7"
   checksum: 10c0/7734f8d7cffe6a92d47fcca82b4846e39ffd79be9c057f3299466696dcdee5379b8a8a3aa6a9692d40bd6900905f689105d9a8ce47882ab22348df10621f70cd
+  languageName: node
+  linkType: hard
+
+"@mediapipe/tasks-vision@npm:^0.10.14":
+  version: 0.10.14
+  resolution: "@mediapipe/tasks-vision@npm:0.10.14"
+  checksum: 10c0/dea1d094153fcb91e76d1a266b6a79baf9cbdd106a786adc0236ded87099b5242c89e0e5b73a3f5d57d7e23ff657dd37f40b9261e12a330762041cd9549fadcc
   languageName: node
   linkType: hard
 
@@ -875,213 +843,213 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm-eabi@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-android-arm-eabi@npm:4.19.0"
+"@rollup/rollup-android-arm-eabi@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-android-arm-eabi@npm:4.21.0"
   conditions: os=android & cpu=arm
   languageName: node
   linkType: hard
 
-"@rollup/rollup-android-arm64@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-android-arm64@npm:4.19.0"
+"@rollup/rollup-android-arm64@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-android-arm64@npm:4.21.0"
   conditions: os=android & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-arm64@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-darwin-arm64@npm:4.19.0"
+"@rollup/rollup-darwin-arm64@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-darwin-arm64@npm:4.21.0"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-darwin-x64@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-darwin-x64@npm:4.19.0"
+"@rollup/rollup-darwin-x64@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-darwin-x64@npm:4.21.0"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-gnueabihf@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.19.0"
+"@rollup/rollup-linux-arm-gnueabihf@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-arm-gnueabihf@npm:4.21.0"
   conditions: os=linux & cpu=arm & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm-musleabihf@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.19.0"
+"@rollup/rollup-linux-arm-musleabihf@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-arm-musleabihf@npm:4.21.0"
   conditions: os=linux & cpu=arm & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-gnu@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.19.0"
+"@rollup/rollup-linux-arm64-gnu@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-arm64-gnu@npm:4.21.0"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-arm64-musl@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.19.0"
+"@rollup/rollup-linux-arm64-musl@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-arm64-musl@npm:4.21.0"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-powerpc64le-gnu@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.19.0"
+"@rollup/rollup-linux-powerpc64le-gnu@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-powerpc64le-gnu@npm:4.21.0"
   conditions: os=linux & cpu=ppc64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-riscv64-gnu@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.19.0"
+"@rollup/rollup-linux-riscv64-gnu@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-riscv64-gnu@npm:4.21.0"
   conditions: os=linux & cpu=riscv64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-s390x-gnu@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.19.0"
+"@rollup/rollup-linux-s390x-gnu@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-s390x-gnu@npm:4.21.0"
   conditions: os=linux & cpu=s390x & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-gnu@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.19.0"
+"@rollup/rollup-linux-x64-gnu@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-x64-gnu@npm:4.21.0"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@rollup/rollup-linux-x64-musl@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-linux-x64-musl@npm:4.19.0"
+"@rollup/rollup-linux-x64-musl@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-linux-x64-musl@npm:4.21.0"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-arm64-msvc@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.19.0"
+"@rollup/rollup-win32-arm64-msvc@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-win32-arm64-msvc@npm:4.21.0"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-ia32-msvc@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.19.0"
+"@rollup/rollup-win32-ia32-msvc@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-win32-ia32-msvc@npm:4.21.0"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@rollup/rollup-win32-x64-msvc@npm:4.19.0":
-  version: 4.19.0
-  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.19.0"
+"@rollup/rollup-win32-x64-msvc@npm:4.21.0":
+  version: 4.21.0
+  resolution: "@rollup/rollup-win32-x64-msvc@npm:4.21.0"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
-"@shikijs/core@npm:1.11.1":
-  version: 1.11.1
-  resolution: "@shikijs/core@npm:1.11.1"
+"@shikijs/core@npm:1.14.1":
+  version: 1.14.1
+  resolution: "@shikijs/core@npm:1.14.1"
   dependencies:
     "@types/hast": "npm:^3.0.4"
-  checksum: 10c0/3d2ccb322ed50617053c73a09b38ce1f3074c04d8a88b223c223bdd20a50e5a7774654e3862d0568d407ac507ee5f43efc1c99469502d685081f5ab000fc85d2
+  checksum: 10c0/a9779634956010788f346f779a8e445d17101cae64e6769a7a4d6d479ccd5d47e6c897fd7a57445cea6b64f1b79f1126ff4f57dbc6ce28c1533f6b74450d752f
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-arm64@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-darwin-arm64@npm:1.7.0"
+"@swc/core-darwin-arm64@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-darwin-arm64@npm:1.7.14"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-darwin-x64@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-darwin-x64@npm:1.7.0"
+"@swc/core-darwin-x64@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-darwin-x64@npm:1.7.14"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm-gnueabihf@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.7.0"
+"@swc/core-linux-arm-gnueabihf@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-linux-arm-gnueabihf@npm:1.7.14"
   conditions: os=linux & cpu=arm
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-gnu@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-linux-arm64-gnu@npm:1.7.0"
+"@swc/core-linux-arm64-gnu@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-linux-arm64-gnu@npm:1.7.14"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-arm64-musl@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-linux-arm64-musl@npm:1.7.0"
+"@swc/core-linux-arm64-musl@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-linux-arm64-musl@npm:1.7.14"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-gnu@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-linux-x64-gnu@npm:1.7.0"
+"@swc/core-linux-x64-gnu@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-linux-x64-gnu@npm:1.7.14"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@swc/core-linux-x64-musl@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-linux-x64-musl@npm:1.7.0"
+"@swc/core-linux-x64-musl@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-linux-x64-musl@npm:1.7.14"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@swc/core-win32-arm64-msvc@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-win32-arm64-msvc@npm:1.7.0"
+"@swc/core-win32-arm64-msvc@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-win32-arm64-msvc@npm:1.7.14"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@swc/core-win32-ia32-msvc@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-win32-ia32-msvc@npm:1.7.0"
+"@swc/core-win32-ia32-msvc@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-win32-ia32-msvc@npm:1.7.14"
   conditions: os=win32 & cpu=ia32
   languageName: node
   linkType: hard
 
-"@swc/core-win32-x64-msvc@npm:1.7.0":
-  version: 1.7.0
-  resolution: "@swc/core-win32-x64-msvc@npm:1.7.0"
+"@swc/core-win32-x64-msvc@npm:1.7.14":
+  version: 1.7.14
+  resolution: "@swc/core-win32-x64-msvc@npm:1.7.14"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
 
 "@swc/core@npm:^1.5.7":
-  version: 1.7.0
-  resolution: "@swc/core@npm:1.7.0"
+  version: 1.7.14
+  resolution: "@swc/core@npm:1.7.14"
   dependencies:
-    "@swc/core-darwin-arm64": "npm:1.7.0"
-    "@swc/core-darwin-x64": "npm:1.7.0"
-    "@swc/core-linux-arm-gnueabihf": "npm:1.7.0"
-    "@swc/core-linux-arm64-gnu": "npm:1.7.0"
-    "@swc/core-linux-arm64-musl": "npm:1.7.0"
-    "@swc/core-linux-x64-gnu": "npm:1.7.0"
-    "@swc/core-linux-x64-musl": "npm:1.7.0"
-    "@swc/core-win32-arm64-msvc": "npm:1.7.0"
-    "@swc/core-win32-ia32-msvc": "npm:1.7.0"
-    "@swc/core-win32-x64-msvc": "npm:1.7.0"
+    "@swc/core-darwin-arm64": "npm:1.7.14"
+    "@swc/core-darwin-x64": "npm:1.7.14"
+    "@swc/core-linux-arm-gnueabihf": "npm:1.7.14"
+    "@swc/core-linux-arm64-gnu": "npm:1.7.14"
+    "@swc/core-linux-arm64-musl": "npm:1.7.14"
+    "@swc/core-linux-x64-gnu": "npm:1.7.14"
+    "@swc/core-linux-x64-musl": "npm:1.7.14"
+    "@swc/core-win32-arm64-msvc": "npm:1.7.14"
+    "@swc/core-win32-ia32-msvc": "npm:1.7.14"
+    "@swc/core-win32-x64-msvc": "npm:1.7.14"
     "@swc/counter": "npm:^0.1.3"
-    "@swc/types": "npm:^0.1.9"
+    "@swc/types": "npm:^0.1.12"
   peerDependencies:
     "@swc/helpers": "*"
   dependenciesMeta:
@@ -1108,7 +1076,7 @@ __metadata:
   peerDependenciesMeta:
     "@swc/helpers":
       optional: true
-  checksum: 10c0/8c98bd94dcf1bb002c84cbb66cce7c656f5e71c8bbe439669af9c24a3d58f7c768b8cdd8d779f9683d9beb14bac1ce56a231b0ebf1f5b24563e7fac46cd5dbb7
+  checksum: 10c0/d98e935a376d6358f53f16a269ee0021c00e2764cc7fabbc594904f283a97200a323b802d35eea034e44af67e8158f641f8ac7a8799b15312cb952765e03ba6b
   languageName: node
   linkType: hard
 
@@ -1119,7 +1087,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/types@npm:^0.1.9":
+"@swc/types@npm:^0.1.12":
   version: 0.1.12
   resolution: "@swc/types@npm:0.1.12"
   dependencies:
@@ -1194,13 +1162,13 @@ __metadata:
   linkType: hard
 
 "@types/dockerode@npm:^3.3.29":
-  version: 3.3.30
-  resolution: "@types/dockerode@npm:3.3.30"
+  version: 3.3.31
+  resolution: "@types/dockerode@npm:3.3.31"
   dependencies:
     "@types/docker-modem": "npm:*"
     "@types/node": "npm:*"
     "@types/ssh2": "npm:*"
-  checksum: 10c0/0428218c3f83374361e62516cec6ad35a2e7d62a2c9fde0bd99da6d8b9932bc0ca57dda0372832f72276126ca2f95ff923acac668ac54debf4fd6851e936ae5d
+  checksum: 10c0/e0b85edcb7065c24d6d8140b90ea3be128451d4ef25d44fe07ef653e931f3ff4ce86ba0fbb0d7037f51296eb5055d17d8d3ac373028c9e13861b3baf249578d8
   languageName: node
   linkType: hard
 
@@ -1243,30 +1211,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:*, @types/node@npm:>=13.7.0":
-  version: 20.14.11
-  resolution: "@types/node@npm:20.14.11"
+"@types/node@npm:*, @types/node@npm:>=13.7.0, @types/node@npm:^22.4.1":
+  version: 22.5.0
+  resolution: "@types/node@npm:22.5.0"
   dependencies:
-    undici-types: "npm:~5.26.4"
-  checksum: 10c0/5306becc0ff41d81b1e31524bd376e958d0741d1ce892dffd586b9ae0cb6553c62b0d62abd16da8bea6b9a2c17572d360450535d7c073794b0cef9cb4e39691e
+    undici-types: "npm:~6.19.2"
+  checksum: 10c0/45aa75c5e71645fac42dced4eff7f197c3fdfff6e8a9fdacd0eb2e748ff21ee70ffb73982f068a58e8d73b2c088a63613142c125236cdcf3c072ea97eada1559
   languageName: node
   linkType: hard
 
 "@types/node@npm:^18.11.18":
-  version: 18.19.41
-  resolution: "@types/node@npm:18.19.41"
+  version: 18.19.45
+  resolution: "@types/node@npm:18.19.45"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: 10c0/fc078939cdec05ca60c557bff55d8d96c8e5695e925ee144d8c67efcd9717ed1ec1e18a476257f2dcc8382d1158dae22b24a423ef3cb833ff9f441a80e80c0e6
-  languageName: node
-  linkType: hard
-
-"@types/node@npm:^22.4.1":
-  version: 22.4.1
-  resolution: "@types/node@npm:22.4.1"
-  dependencies:
-    undici-types: "npm:~6.19.2"
-  checksum: 10c0/e42607438fcbd3a6aebd09084868fa0b22a4b0daf9eda79ed615df7ff8ae95e35ea56e090e1f3140ebae76b640abe42d4a6d5b60c0819eadf499adca737305b6
+  checksum: 10c0/79c324176411dcfa92f76b0ffc0673aa4bd8da82d003b44633e927c9493cdc46c35f04c0873b096b23b12bab090a6bbdea21242b3bbb2ea5dc1d9bf72adaa04f
   languageName: node
   linkType: hard
 
@@ -1287,12 +1246,12 @@ __metadata:
   linkType: hard
 
 "@types/react@npm:*, @types/react@npm:^18.2.55, @types/react@npm:^18.3.3":
-  version: 18.3.3
-  resolution: "@types/react@npm:18.3.3"
+  version: 18.3.4
+  resolution: "@types/react@npm:18.3.4"
   dependencies:
     "@types/prop-types": "npm:*"
     csstype: "npm:^3.0.2"
-  checksum: 10c0/fe455f805c5da13b89964c3d68060cebd43e73ec15001a68b34634604a78140e6fc202f3f61679b9d809dde6d7a7c2cb3ed51e0fd1462557911db09879b55114
+  checksum: 10c0/5c52e1e6f540cff21e3c2a5212066d02e005f6fb21e4a536a29097fae878db9f407cd7a4b43778f51359349c5f692e08bc77ddb5f5cecbfca9ca4d4e3c91a48e
   languageName: node
   linkType: hard
 
@@ -1306,11 +1265,11 @@ __metadata:
   linkType: hard
 
 "@types/ssh2@npm:*":
-  version: 1.15.0
-  resolution: "@types/ssh2@npm:1.15.0"
+  version: 1.15.1
+  resolution: "@types/ssh2@npm:1.15.1"
   dependencies:
     "@types/node": "npm:^18.11.18"
-  checksum: 10c0/055c271845847867c365b0c002e59536608e400864aea4f54ebc72e8588b92dbc4b6572e3095092dba0d86d49898e2180a389810269d119f897972ebbddb4a7f
+  checksum: 10c0/83c83684e0d620ab940e05c5b7e846eacf6c56761e421dbe6a5a51daa09c82fb71ea4843b792b6e6b2edd0bee8eb665034ffd73978d936b9f008c553bcc38ea7
   languageName: node
   linkType: hard
 
@@ -1325,9 +1284,9 @@ __metadata:
   linkType: hard
 
 "@types/unist@npm:*":
-  version: 3.0.2
-  resolution: "@types/unist@npm:3.0.2"
-  checksum: 10c0/39f220ce184a773c55c18a127062bfc4d0d30c987250cd59bab544d97be6cfec93717a49ef96e81f024b575718f798d4d329eb81c452fc57d6d051af8b043ebf
+  version: 3.0.3
+  resolution: "@types/unist@npm:3.0.3"
+  checksum: 10c0/2b1e4adcab78388e088fcc3c0ae8700f76619dbcb4741d7d201f87e2cb346bfc29a89003cfea2d76c996e1061452e14fcd737e8b25aacf949c1f2d6b2bc3dd60
   languageName: node
   linkType: hard
 
@@ -1786,9 +1745,9 @@ __metadata:
   linkType: hard
 
 "async@npm:^3.2.4":
-  version: 3.2.5
-  resolution: "async@npm:3.2.5"
-  checksum: 10c0/1408287b26c6db67d45cb346e34892cee555b8b59e6c68e6f8c3e495cad5ca13b4f218180e871f3c2ca30df4ab52693b66f2f6ff43644760cab0b2198bda79c1
+  version: 3.2.6
+  resolution: "async@npm:3.2.6"
+  checksum: 10c0/36484bb15ceddf07078688d95e27076379cc2f87b10c03b6dd8a83e89475a3c8df5848859dd06a4c95af1e4c16fc973de0171a77f18ea00be899aca2a4f85e70
   languageName: node
   linkType: hard
 
@@ -1929,21 +1888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.23.1":
-  version: 4.23.2
-  resolution: "browserslist@npm:4.23.2"
-  dependencies:
-    caniuse-lite: "npm:^1.0.30001640"
-    electron-to-chromium: "npm:^1.4.820"
-    node-releases: "npm:^2.0.14"
-    update-browserslist-db: "npm:^1.1.0"
-  bin:
-    browserslist: cli.js
-  checksum: 10c0/0217d23c69ed61cdd2530c7019bf7c822cd74c51f8baab18dd62457fed3129f52499f8d3a6f809ae1fb7bb3050aa70caa9a529cc36c7478427966dbf429723a5
-  languageName: node
-  linkType: hard
-
-"browserslist@npm:^4.23.3":
+"browserslist@npm:^4.23.1, browserslist@npm:^4.23.3":
   version: 4.23.3
   resolution: "browserslist@npm:4.23.3"
   dependencies:
@@ -2039,17 +1984,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001640":
-  version: 1.0.30001643
-  resolution: "caniuse-lite@npm:1.0.30001643"
-  checksum: 10c0/7fcd0fd180bbe6764311ad57b0d39c23afdcc3bb1d8f804e7a76752c62a85b1bb7cf74b672d9da2f0afe7ad75336ff811a6fe279eb2a54bc04c272b6b62e57f1
-  languageName: node
-  linkType: hard
-
 "caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001649
-  resolution: "caniuse-lite@npm:1.0.30001649"
-  checksum: 10c0/0ca2f3776324acfc36d72a575e72ffd1408b91f0ac462a6f0aa08ea24d0d16e83f85f652e19d40e6d6d82ab0fb588740f948e7c88d2818fe6bcd68f70ca33acf
+  version: 1.0.30001651
+  resolution: "caniuse-lite@npm:1.0.30001651"
+  checksum: 10c0/7821278952a6dbd17358e5d08083d258f092e2a530f5bc1840657cb140fbbc5ec44293bc888258c44a18a9570cde149ed05819ac8320b9710cf22f699891e6ad
   languageName: node
   linkType: hard
 
@@ -2347,19 +2285,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5":
-  version: 4.3.5
-  resolution: "debug@npm:4.3.5"
-  dependencies:
-    ms: "npm:2.1.2"
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 10c0/082c375a2bdc4f4469c99f325ff458adad62a3fc2c482d59923c260cb08152f34e2659f72b3767db8bb2f21ca81a60a42d1019605a412132d7b9f59363a005cc
-  languageName: node
-  linkType: hard
-
-"debug@npm:~4.3.6":
+"debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:~4.3.6":
   version: 4.3.6
   resolution: "debug@npm:4.3.6"
   dependencies:
@@ -2474,17 +2400,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.4.820":
-  version: 1.5.0
-  resolution: "electron-to-chromium@npm:1.5.0"
-  checksum: 10c0/b978d03009760151fcc1c24c727016161ba4ed4b0946f848f52fb6767624e5646d5ebc73399aa938bcd8c717b89007b760f737fbf473433aa17405e011d6668c
-  languageName: node
-  linkType: hard
-
 "electron-to-chromium@npm:^1.5.4":
-  version: 1.5.4
-  resolution: "electron-to-chromium@npm:1.5.4"
-  checksum: 10c0/139abf1b7281c2f3288819fb9b114f09d541ac38c9f0373f194ce2d483d82d118b8751f1b2a59b04ed0d8f414071b58508a40050fc0f23b5aa7e38d11d0cf30c
+  version: 1.5.13
+  resolution: "electron-to-chromium@npm:1.5.13"
+  checksum: 10c0/1d88ac39447e1d718c4296f92fe89836df4688daf2d362d6c49108136795f05a56dd9c950f1c6715e0395fa037c3b5f5ea686c543fdc90e6d74a005877c45022
   languageName: node
   linkType: hard
 
@@ -2677,11 +2596,11 @@ __metadata:
   linkType: hard
 
 "eslint-plugin-react-refresh@npm:^0.4.9":
-  version: 0.4.9
-  resolution: "eslint-plugin-react-refresh@npm:0.4.9"
+  version: 0.4.11
+  resolution: "eslint-plugin-react-refresh@npm:0.4.11"
   peerDependencies:
     eslint: ">=7"
-  checksum: 10c0/5be0677746e32d14d2711d8cba30d59b9ffec5d4a46ccae94602f7812176ac491e47a13e9331a3beeb20f29e15fcb2c69295141b582523843ee386e8b716bb30
+  checksum: 10c0/0c7d4ce30a70fbd6460ea9ca45b029b1cc806fd922d308ad332315d0e1725a37a578283809913bf7a7c84c613e3313e891dde7692a8e6ef2979dbff7edf45901
   languageName: node
   linkType: hard
 
@@ -2986,12 +2905,12 @@ __metadata:
   linkType: hard
 
 "foreground-child@npm:^3.1.0":
-  version: 3.2.1
-  resolution: "foreground-child@npm:3.2.1"
+  version: 3.3.0
+  resolution: "foreground-child@npm:3.3.0"
   dependencies:
     cross-spawn: "npm:^7.0.0"
     signal-exit: "npm:^4.0.1"
-  checksum: 10c0/9a53a33dbd87090e9576bef65fb4a71de60f6863a8062a7b11bc1cbe3cc86d428677d7c0b9ef61cdac11007ac580006f78bd5638618d564cfd5e6fd713d6878f
+  checksum: 10c0/028f1d41000553fcfa6c4bb5c372963bf3d9bf0b1f25a87d1a6253014343fb69dfb1b42d9625d7cf44c8ba429940f3d0ff718b62105d4d4a4f6ef8ca0a53faa2
   languageName: node
   linkType: hard
 
@@ -3282,11 +3201,11 @@ __metadata:
   linkType: hard
 
 "husky@npm:^9.1.4":
-  version: 9.1.4
-  resolution: "husky@npm:9.1.4"
+  version: 9.1.5
+  resolution: "husky@npm:9.1.5"
   bin:
     husky: bin.js
-  checksum: 10c0/f5185003bef9ad9ec3f40e821963e4c12409b993fdcab89e3d660bed7d8c9d8bfd399f05222e27e0ead6589601fb1bb08d1a589c51751a4ab0547ead3429b8de
+  checksum: 10c0/f42efb95a026303eb880898760f802d88409780dd72f17781d2dfc302177d4f80b641cf1f1694f53f6d97c536c7397684133d8c8fe4a4426f7460186a7d1c6b8
   languageName: node
   linkType: hard
 
@@ -3307,9 +3226,9 @@ __metadata:
   linkType: hard
 
 "ignore@npm:^5.2.0, ignore@npm:^5.3.1":
-  version: 5.3.1
-  resolution: "ignore@npm:5.3.1"
-  checksum: 10c0/703f7f45ffb2a27fb2c5a8db0c32e7dee66b33a225d28e8db4e1be6474795f606686a6e3bcc50e1aa12f2042db4c9d4a7d60af3250511de74620fbed052ea4cd
+  version: 5.3.2
+  resolution: "ignore@npm:5.3.2"
+  checksum: 10c0/f9f652c957983634ded1e7f02da3b559a0d4cc210fca3792cb67f1b153623c9c42efdc1c4121af171e295444459fc4a9201101fb041b1104a3c000bccb188337
   languageName: node
   linkType: hard
 
@@ -3374,11 +3293,11 @@ __metadata:
   linkType: hard
 
 "is-core-module@npm:^2.13.0":
-  version: 2.15.0
-  resolution: "is-core-module@npm:2.15.0"
+  version: 2.15.1
+  resolution: "is-core-module@npm:2.15.1"
   dependencies:
     hasown: "npm:^2.0.2"
-  checksum: 10c0/da161f3d9906f459486da65609b2f1a2dfdc60887c689c234d04e88a062cb7920fa5be5fb7ab08dc43b732929653c4135ef05bf77888ae2a9040ce76815eb7b1
+  checksum: 10c0/53432f10c69c40bfd2fa8914133a68709ff9498c86c3bf5fca3cdf3145a56fd2168cbf4a43b29843a6202a120a5f9c5ffba0a4322e1e3441739bc0b641682612
   languageName: node
   linkType: hard
 
@@ -3830,11 +3749,11 @@ __metadata:
   linkType: hard
 
 "magic-string@npm:^0.30.10":
-  version: 0.30.10
-  resolution: "magic-string@npm:0.30.10"
+  version: 0.30.11
+  resolution: "magic-string@npm:0.30.11"
   dependencies:
-    "@jridgewell/sourcemap-codec": "npm:^1.4.15"
-  checksum: 10c0/aa9ca17eae571a19bce92c8221193b6f93ee8511abb10f085e55ffd398db8e4c089a208d9eac559deee96a08b7b24d636ea4ab92f09c6cf42a7d1af51f7fd62b
+    "@jridgewell/sourcemap-codec": "npm:^1.5.0"
+  checksum: 10c0/b9eb370773d0bd90ca11a848753409d8e5309b1ad56d2a1aa49d6649da710a6d2fe7237ad1a643c5a5d3800de2b9946ed9690acdfc00e6cc1aeafff3ab1752c4
   languageName: node
   linkType: hard
 
@@ -4136,7 +4055,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.14, node-releases@npm:^2.0.18":
+"node-releases@npm:^2.0.18":
   version: 2.0.18
   resolution: "node-releases@npm:2.0.18"
   checksum: 10c0/786ac9db9d7226339e1dc84bbb42007cb054a346bd9257e6aa154d294f01bc6a6cddb1348fa099f079be6580acbb470e3c048effd5f719325abd0179e566fd27
@@ -4475,12 +4394,12 @@ __metadata:
   linkType: hard
 
 "postcss-selector-parser@npm:^6.0.11, postcss-selector-parser@npm:^6.1.1":
-  version: 6.1.1
-  resolution: "postcss-selector-parser@npm:6.1.1"
+  version: 6.1.2
+  resolution: "postcss-selector-parser@npm:6.1.2"
   dependencies:
     cssesc: "npm:^3.0.0"
     util-deprecate: "npm:^1.0.2"
-  checksum: 10c0/5608765e033fee35d448e1f607ffbaa750eb86901824a8bc4a911ea8bc137cb82f29239330787427c5d3695afd90d8721e190f211dbbf733e25033d8b3100763
+  checksum: 10c0/523196a6bd8cf660bdf537ad95abd79e546d54180f9afb165a4ab3e651ac705d0f8b8ce6b3164fb9e3279ce482c5f751a69eb2d3a1e8eb0fd5e82294fb3ef13e
   languageName: node
   linkType: hard
 
@@ -4491,18 +4410,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8.4.23, postcss@npm:^8.4.39":
-  version: 8.4.39
-  resolution: "postcss@npm:8.4.39"
-  dependencies:
-    nanoid: "npm:^3.3.7"
-    picocolors: "npm:^1.0.1"
-    source-map-js: "npm:^1.2.0"
-  checksum: 10c0/16f5ac3c4e32ee76d1582b3c0dcf1a1fdb91334a45ad755eeb881ccc50318fb8d64047de4f1601ac96e30061df203f0f2e2edbdc0bfc49b9c57bc9fb9bedaea3
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.4.41":
+"postcss@npm:^8.4.23, postcss@npm:^8.4.41":
   version: 8.4.41
   resolution: "postcss@npm:8.4.41"
   dependencies:
@@ -4639,8 +4547,8 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.2.4, protobufjs@npm:^7.2.6, protobufjs@npm:^7.3.0":
-  version: 7.3.2
-  resolution: "protobufjs@npm:7.3.2"
+  version: 7.4.0
+  resolution: "protobufjs@npm:7.4.0"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
@@ -4654,7 +4562,7 @@ __metadata:
     "@protobufjs/utf8": "npm:^1.1.0"
     "@types/node": "npm:>=13.7.0"
     long: "npm:^5.0.0"
-  checksum: 10c0/b87e38fffc989793099010439a7ff45a0a57ef5b8f44b5209f06bfa5085ac96a365aa37eb3c79bd6954d6ef1b50fc69da37dae8ea2a31d90b7bc8fb2fa0e3955
+  checksum: 10c0/a5460a63fe596523b9a067cbce39a6b310d1a71750fda261f076535662aada97c24450e18c5bc98a27784f70500615904ff1227e1742183509f0db4fdede669b
   languageName: node
   linkType: hard
 
@@ -4865,26 +4773,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rollup@npm:^4.13.0":
-  version: 4.19.0
-  resolution: "rollup@npm:4.19.0"
+"rollup@npm:^4.20.0":
+  version: 4.21.0
+  resolution: "rollup@npm:4.21.0"
   dependencies:
-    "@rollup/rollup-android-arm-eabi": "npm:4.19.0"
-    "@rollup/rollup-android-arm64": "npm:4.19.0"
-    "@rollup/rollup-darwin-arm64": "npm:4.19.0"
-    "@rollup/rollup-darwin-x64": "npm:4.19.0"
-    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.19.0"
-    "@rollup/rollup-linux-arm-musleabihf": "npm:4.19.0"
-    "@rollup/rollup-linux-arm64-gnu": "npm:4.19.0"
-    "@rollup/rollup-linux-arm64-musl": "npm:4.19.0"
-    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.19.0"
-    "@rollup/rollup-linux-riscv64-gnu": "npm:4.19.0"
-    "@rollup/rollup-linux-s390x-gnu": "npm:4.19.0"
-    "@rollup/rollup-linux-x64-gnu": "npm:4.19.0"
-    "@rollup/rollup-linux-x64-musl": "npm:4.19.0"
-    "@rollup/rollup-win32-arm64-msvc": "npm:4.19.0"
-    "@rollup/rollup-win32-ia32-msvc": "npm:4.19.0"
-    "@rollup/rollup-win32-x64-msvc": "npm:4.19.0"
+    "@rollup/rollup-android-arm-eabi": "npm:4.21.0"
+    "@rollup/rollup-android-arm64": "npm:4.21.0"
+    "@rollup/rollup-darwin-arm64": "npm:4.21.0"
+    "@rollup/rollup-darwin-x64": "npm:4.21.0"
+    "@rollup/rollup-linux-arm-gnueabihf": "npm:4.21.0"
+    "@rollup/rollup-linux-arm-musleabihf": "npm:4.21.0"
+    "@rollup/rollup-linux-arm64-gnu": "npm:4.21.0"
+    "@rollup/rollup-linux-arm64-musl": "npm:4.21.0"
+    "@rollup/rollup-linux-powerpc64le-gnu": "npm:4.21.0"
+    "@rollup/rollup-linux-riscv64-gnu": "npm:4.21.0"
+    "@rollup/rollup-linux-s390x-gnu": "npm:4.21.0"
+    "@rollup/rollup-linux-x64-gnu": "npm:4.21.0"
+    "@rollup/rollup-linux-x64-musl": "npm:4.21.0"
+    "@rollup/rollup-win32-arm64-msvc": "npm:4.21.0"
+    "@rollup/rollup-win32-ia32-msvc": "npm:4.21.0"
+    "@rollup/rollup-win32-x64-msvc": "npm:4.21.0"
     "@types/estree": "npm:1.0.5"
     fsevents: "npm:~2.3.2"
   dependenciesMeta:
@@ -4924,7 +4832,7 @@ __metadata:
       optional: true
   bin:
     rollup: dist/bin/rollup
-  checksum: 10c0/1c656853895f6c7d55492db4661c79d37a3046cff465f4924ac5f053b0f80a079e36f901b154dbe819d9e94dcd83e90e51c7f95e7158bef1a07ceb60df736285
+  checksum: 10c0/984beb858da245c5e3a9027d6d87e67ad6443f1b46eab07685b861d9e49da5856693265c62a6f8262c36d11c9092713a96a9124f43e6de6698eb84d77118496a
   languageName: node
   linkType: hard
 
@@ -5011,12 +4919,12 @@ __metadata:
   linkType: hard
 
 "shiki@npm:^1.9.1":
-  version: 1.11.1
-  resolution: "shiki@npm:1.11.1"
+  version: 1.14.1
+  resolution: "shiki@npm:1.14.1"
   dependencies:
-    "@shikijs/core": "npm:1.11.1"
+    "@shikijs/core": "npm:1.14.1"
     "@types/hast": "npm:^3.0.4"
-  checksum: 10c0/ef97035d4cc3ffcee2e4f60080ea72cf5b3b895e662eae762cf4e0fa36b03210335e4403157f77c86f2d0c7a74881f4cb2e37c151f433d1b1c1a305cf979cf09
+  checksum: 10c0/756f45917f281e158eef114b985b9a4cae9f0470f955e2f96f4473a3aed327dc1d653b9bd6280eb28398bd0da6d533caa4fce61b716c1263c5d85df53964ade2
   languageName: node
   linkType: hard
 
@@ -5168,8 +5076,8 @@ __metadata:
   linkType: hard
 
 "streamx@npm:^2.15.0, streamx@npm:^2.18.0":
-  version: 2.18.0
-  resolution: "streamx@npm:2.18.0"
+  version: 2.19.0
+  resolution: "streamx@npm:2.19.0"
   dependencies:
     bare-events: "npm:^2.2.0"
     fast-fifo: "npm:^1.3.2"
@@ -5178,7 +5086,7 @@ __metadata:
   dependenciesMeta:
     bare-events:
       optional: true
-  checksum: 10c0/ef50f419252a73dd35abcde72329eafbf5ad9cd2e27f0cc3abebeff6e0dbea124ac6d3e16acbdf081cce41b4125393ac22f9848fcfa19e640830734883e622ba
+  checksum: 10c0/5833a2c1226488a015e8efde08c6cd4983d7d20098b2210d09594b23f598a8b028c083d542621e2e91ddcb33a266233c3524c60152203be40f1dd816b9ede9da
   languageName: node
   linkType: hard
 
@@ -5491,16 +5399,16 @@ __metadata:
   linkType: hard
 
 "tinybench@npm:^2.8.0":
-  version: 2.8.0
-  resolution: "tinybench@npm:2.8.0"
-  checksum: 10c0/5a9a642351fa3e4955e0cbf38f5674be5f3ba6730fd872fd23a5c953ad6c914234d5aba6ea41ef88820180a81829ceece5bd8d3967c490c5171bca1141c2f24d
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
   languageName: node
   linkType: hard
 
 "tinypool@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "tinypool@npm:1.0.0"
-  checksum: 10c0/71b20b9c54366393831c286a0772380c20f8cad9546d724c484edb47aea3228f274c58e98cf51d28c40869b39f5273209ef3ea94a9d2a23f8b292f4731cd3e4e
+  version: 1.0.1
+  resolution: "tinypool@npm:1.0.1"
+  checksum: 10c0/90939d6a03f1519c61007bf416632dc1f0b9c1a9dd673c179ccd9e36a408437384f984fc86555a5d040d45b595abc299c3bb39d354439e98a090766b5952e73d
   languageName: node
   linkType: hard
 
@@ -5577,8 +5485,8 @@ __metadata:
   linkType: hard
 
 "ts-proto@npm:^2.0.2":
-  version: 2.0.2
-  resolution: "ts-proto@npm:2.0.2"
+  version: 2.0.3
+  resolution: "ts-proto@npm:2.0.3"
   dependencies:
     "@bufbuild/protobuf": "npm:^2.0.0"
     case-anything: "npm:^2.1.13"
@@ -5586,7 +5494,7 @@ __metadata:
     ts-proto-descriptors: "npm:1.16.0"
   bin:
     protoc-gen-ts_proto: protoc-gen-ts_proto
-  checksum: 10c0/33b44c53152022ed491f9c97f7843fddb0afa78f664d34bc5ce8c76627c77e25eda68a603c36387a5adb86cf52e0fe41b7c196ceafc163f1175377f45e6aea6f
+  checksum: 10c0/1717295f7155d660b749ce89ba00856f9cde964a7fd96b3d48b079b0df79825faa7f0157ff0e98a07d09c831d64b406451e7558d09e5142df1ba84fb6c8107ac
   languageName: node
   linkType: hard
 
@@ -5835,6 +5743,7 @@ __metadata:
   resolution: "videoroom@workspace:examples/react-client/videoroom"
   dependencies:
     "@fishjam-cloud/react-client": "workspace:*"
+    "@mediapipe/tasks-vision": "npm:^0.10.14"
     "@types/react": "npm:^18.3.3"
     "@types/react-dom": "npm:^18.3.0"
     "@vitejs/plugin-react-swc": "npm:^3.5.0"
@@ -5916,54 +5825,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"vite@npm:^5.0.0":
-  version: 5.3.4
-  resolution: "vite@npm:5.3.4"
-  dependencies:
-    esbuild: "npm:^0.21.3"
-    fsevents: "npm:~2.3.3"
-    postcss: "npm:^8.4.39"
-    rollup: "npm:^4.13.0"
-  peerDependencies:
-    "@types/node": ^18.0.0 || >=20.0.0
-    less: "*"
-    lightningcss: ^1.21.0
-    sass: "*"
-    stylus: "*"
-    sugarss: "*"
-    terser: ^5.4.0
-  dependenciesMeta:
-    fsevents:
-      optional: true
-  peerDependenciesMeta:
-    "@types/node":
-      optional: true
-    less:
-      optional: true
-    lightningcss:
-      optional: true
-    sass:
-      optional: true
-    stylus:
-      optional: true
-    sugarss:
-      optional: true
-    terser:
-      optional: true
-  bin:
-    vite: bin/vite.js
-  checksum: 10c0/604a1c8698bcf09d6889533c552f20137c80cb5027e9e7ddf6215d51e3df763414f8712168c22b3c8c16383aff9447094c05f21d7cca3c115874ff9d12e1538e
-  languageName: node
-  linkType: hard
-
-"vite@npm:^5.4.1":
-  version: 5.4.1
-  resolution: "vite@npm:5.4.1"
+"vite@npm:^5.0.0, vite@npm:^5.4.1":
+  version: 5.4.2
+  resolution: "vite@npm:5.4.2"
   dependencies:
     esbuild: "npm:^0.21.3"
     fsevents: "npm:~2.3.3"
     postcss: "npm:^8.4.41"
-    rollup: "npm:^4.13.0"
+    rollup: "npm:^4.20.0"
   peerDependencies:
     "@types/node": ^18.0.0 || >=20.0.0
     less: "*"
@@ -5995,7 +5864,7 @@ __metadata:
       optional: true
   bin:
     vite: bin/vite.js
-  checksum: 10c0/b9ea824f1a946aa494f756e6d9dd88869baa62ae5ba3071b32b6a20958fd622cb624c860bdd7daee201c83ca029feaf8bbe2d2a6e172a5d49308772f8899d86d
+  checksum: 10c0/23e347ca8aa6f0a774227e4eb7abae228f12c6806a727b046aa75e7ee37ffc2d68cff74360e12a42c347f79adc294e2363bc723b957bf4b382b5a8fb39e4df9d
   languageName: node
   linkType: hard
 
@@ -6077,9 +5946,9 @@ __metadata:
   linkType: hard
 
 "vscode-languageserver-textdocument@npm:^1.0.1":
-  version: 1.0.11
-  resolution: "vscode-languageserver-textdocument@npm:1.0.11"
-  checksum: 10c0/1996a38e24571e05aa21dd4f46e0a6849e22301c9a66996762e77d9c6df3622de0bd31cd5742a0c0c47fb9dfd00b310ad08c44d08241873ea571edacd5238da6
+  version: 1.0.12
+  resolution: "vscode-languageserver-textdocument@npm:1.0.12"
+  checksum: 10c0/534349894b059602c4d97615a1147b6c4c031141c2093e59657f54e38570f5989c21b376836f13b9375419869242e9efb4066643208b21ab1e1dee111a0f00fb
   languageName: node
   linkType: hard
 
@@ -6203,16 +6072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yaml@npm:^2.2.2, yaml@npm:^2.3.4, yaml@npm:^2.4.5":
-  version: 2.4.5
-  resolution: "yaml@npm:2.4.5"
-  bin:
-    yaml: bin.mjs
-  checksum: 10c0/e1ee78b381e5c710f715cc4082fd10fc82f7f5c92bd6f075771d20559e175616f56abf1c411f545ea0e9e16e4f84a83a50b42764af5f16ec006328ba9476bb31
-  languageName: node
-  linkType: hard
-
-"yaml@npm:~2.5.0":
+"yaml@npm:^2.2.2, yaml@npm:^2.3.4, yaml@npm:^2.4.5, yaml@npm:~2.5.0":
   version: 2.5.0
   resolution: "yaml@npm:2.5.0"
   bin:


### PR DESCRIPTION
## Description

Adds track middleware to screenshare and video/audio managers.
Additionally, the track manager has been rewritten from a class to react hook.

## Motivation and Context

Track middleware allows easy manipulation of the tracks managed by the SDK before streaming them out.

I also rewritten the track manager to a hook, because I needed a state to store the middleware.
Adding a property to the TrackManager class wasn't enough, I also needed to synchronize with the react state.
Instead of pursuing the event emitting pattern, I decided to introduce an internal hook.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
