### PR TITLE
Simplify Device API

### DIFF
--- a/examples/react-client/use-camera-and-microphone/src/AdditionalControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/AdditionalControls.tsx
@@ -25,6 +25,7 @@ export const AdditionalControls = () => {
     <div>
       <div className="flex flex-row p-2">
         <div className="m-2">Separate component</div>
+
         <button
           className={`btn btn-sm ${show ? "btn-info" : "btn-success"}`}
           onClick={() => {
@@ -34,26 +35,31 @@ export const AdditionalControls = () => {
           {show ? "Hide" : "Show"}
         </button>
       </div>
+
       {show && (
         <div className="flex flex-row flex-wrap gap-2 p-2 md:grid md:grid-cols-2">
           <div className="grid grid-cols-2 gap-2">
             <DeviceControls device={camera} type={"video"} status={status} />
+
             <DeviceControls
               device={microphone}
               type={"audio"}
               status={status}
             />
           </div>
+
           <div>
             <h3>Local:</h3>
+
             <div className="max-w-[500px]">
-              {camera?.track?.kind === "video" && (
-                <VideoPlayer stream={camera?.stream} />
+              {camera.streamedTrack?.kind === "video" && (
+                <VideoPlayer stream={camera.stream} />
               )}
-              {microphone?.track?.kind === "audio" && (
+
+              {microphone.streamedTrack?.kind === "audio" && (
                 <AudioVisualizer
-                  stream={microphone?.stream}
-                  trackId={microphone?.track.id}
+                  stream={microphone.stream}
+                  trackId={microphone.streamedTrackId}
                 />
               )}
             </div>

--- a/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
@@ -1,15 +1,18 @@
-import type { PeerStatus, UserMediaAPI } from "@fishjam-cloud/react-client";
-import type { TrackManager } from "@fishjam-cloud/react-client";
+import type {
+  PeerStatus,
+  Device,
+  AudioDevice,
+} from "@fishjam-cloud/react-client";
 
 type DeviceControlsProps = {
   status: PeerStatus;
 } & (
   | {
-      device: UserMediaAPI & TrackManager;
+      device: AudioDevice;
       type: "audio";
     }
   | {
-      device: UserMediaAPI & TrackManager;
+      device: Device;
       type: "video";
     }
 );
@@ -19,7 +22,7 @@ export const DeviceControls = ({
   type,
   status,
 }: DeviceControlsProps) => {
-  const isDeviceStreaming = !!device.getCurrentTrack()?.trackId;
+  const isDeviceStreaming = !!device.streamedTrack;
   return (
     <div className="flex flex-col gap-2">
       <button
@@ -44,7 +47,7 @@ export const DeviceControls = ({
 
       <button
         className="btn btn-success btn-sm"
-        disabled={!device?.stream || device?.enabled}
+        disabled={!device?.stream || !device?.paused}
         onClick={() => {
           device.enableTrack();
         }}
@@ -54,7 +57,7 @@ export const DeviceControls = ({
 
       <button
         className="btn btn-error btn-sm"
-        disabled={!device?.enabled}
+        disabled={!device?.paused}
         onClick={() => {
           device?.disableTrack();
         }}

--- a/examples/react-client/use-camera-and-microphone/src/MainControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/MainControls.tsx
@@ -172,10 +172,12 @@ export const MainControls = () => {
           onChange={(e) => setToken(() => e?.target?.value)}
           placeholder="token"
         />
+
         <div className="flex w-full flex-row flex-wrap items-center gap-2">
           <div className="form-control">
             <label className="label flex cursor-pointer flex-row gap-2">
               <span className="label-text">Autostart</span>
+
               <input
                 type="checkbox"
                 checked={autostart}
@@ -268,12 +270,14 @@ export const MainControls = () => {
             set={setBroadcastVideoOnConnect}
             radioClass="radio-primary"
           />
+
           <ThreeStateRadio
             name="Broadcast video on device start (default false)"
             value={broadcastVideoOnDeviceStart}
             set={setBroadcastVideoOnDeviceStart}
             radioClass="radio-primary"
           />
+
           <Radio
             name='Broadcast video on device change (default "replace")'
             value={broadcastVideoOnDeviceChange}
@@ -288,6 +292,7 @@ export const MainControls = () => {
               { value: "replace", key: "replace" },
             ]}
           />
+
           <Radio
             name='Broadcast video on device stop (default "mute")'
             value={broadcastVideoOnDeviceStop}
@@ -309,12 +314,14 @@ export const MainControls = () => {
             set={setBroadcastAudioOnConnect}
             radioClass="radio-secondary"
           />
+
           <ThreeStateRadio
             name="Broadcast audio on device start (default false)"
             value={broadcastAudioOnDeviceStart}
             set={setBroadcastAudioOnDeviceStart}
             radioClass="radio-secondary"
           />
+
           <Radio
             name='Broadcast audio on device change (default "replace")'
             value={broadcastAudioOnDeviceChange}
@@ -329,6 +336,7 @@ export const MainControls = () => {
               { value: "replace", key: "replace" },
             ]}
           />
+
           <Radio
             name='Broadcast audio on device stop (default "mute")'
             value={broadcastAudioOnDeviceStop}
@@ -350,6 +358,7 @@ export const MainControls = () => {
             set={setBroadcastScreenShareOnConnect}
             radioClass="radio-accent"
           />
+
           <ThreeStateRadio
             name="Broadcast screen share on device start (default false)"
             value={broadcastScreenShareOnDeviceStart}
@@ -357,10 +366,11 @@ export const MainControls = () => {
             radioClass="radio-accent"
           />
         </div>
+
         <DeviceSelector
           name="Video"
-          activeDevice={video?.deviceInfo?.label ?? null}
-          devices={video?.devices || null}
+          activeDevice={video.activeDevice?.label ?? null}
+          devices={video.devices}
           setInput={(deviceId) => {
             if (!deviceId) return;
             video.initialize(deviceId);
@@ -373,8 +383,8 @@ export const MainControls = () => {
 
         <DeviceSelector
           name="Audio"
-          activeDevice={audio?.deviceInfo?.label ?? null}
-          devices={audio?.devices || null}
+          activeDevice={audio.activeDevice?.label ?? null}
+          devices={audio.devices || null}
           setInput={(deviceId) => {
             if (!deviceId) return;
             audio.initialize(deviceId);
@@ -387,6 +397,7 @@ export const MainControls = () => {
 
         <div className="grid grid-cols-3 gap-2">
           <DeviceControls device={video} type="video" status={status} />
+
           <DeviceControls device={audio} type="audio" status={status} />
 
           <ScreenShareControls />
@@ -396,16 +407,20 @@ export const MainControls = () => {
         <div className="prose grid grid-rows-2">
           <div>
             <h3>Local:</h3>
-            <p>Video {video.track?.label}</p>
-            <p>Audio {audio.track?.label}</p>
+
+            <p>Video {video.streamedTrack?.label}</p>
+
+            <p>Audio {audio.streamedTrack?.label}</p>
+
             <div className="max-w-[500px]">
-              {video?.track?.kind === "video" && (
+              {video.streamedTrack?.kind === "video" && (
                 <VideoPlayer stream={video.stream} />
               )}
-              {audio?.track?.kind === "audio" && (
+
+              {audio.streamedTrack?.kind === "audio" && (
                 <AudioVisualizer
                   stream={audio.stream}
-                  trackId={audio.track.id ?? null}
+                  trackId={audio.streamedTrackId}
                 />
               )}
 
@@ -424,13 +439,16 @@ export const MainControls = () => {
 
           <div>
             <h3>Streaming:</h3>
+
             <div className="flex max-w-[500px] flex-col gap-2">
               {local.map(({ trackId, stream, track }) => (
                 <div key={trackId} className="max-w-[500px] border">
                   <span>trackId: {trackId}</span>
+
                   {track?.kind === "audio" && (
                     <AudioVisualizer trackId={track.id} stream={stream} />
                   )}
+
                   {track?.kind === "video" && (
                     <VideoPlayer key={trackId} stream={stream} />
                   )}

--- a/examples/react-client/videoroom/src/App.tsx
+++ b/examples/react-client/videoroom/src/App.tsx
@@ -10,14 +10,12 @@ function App() {
   const { localParticipant, participants } = useParticipants();
 
   useEffect(() => {
-    client.initializeDevices({
-      videoTrackConstraints: true,
-      audioTrackConstraints: true,
-    });
+    client.initializeDevices();
   }, [client]);
+
   return (
-    <main className="w-screen h-screen flex">
-      <section className="w-1/3 bg-zinc-200 p-4 h-full space-y-8">
+    <main className="flex h-screen w-screen">
+      <section className="h-full w-1/3 space-y-8 bg-zinc-200 p-4">
         <h1 className="text-xl">Videoroom example</h1>
 
         <RoomConnector />
@@ -25,8 +23,8 @@ function App() {
         <DevicePicker />
       </section>
 
-      <div className="w-full h-full p-4">
-        <section className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+      <div className="h-full w-full p-4">
+        <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
           {localParticipant && (
             <VideoTracks
               videoTracks={localParticipant.videoTracks}
@@ -42,6 +40,7 @@ function App() {
               id={id}
             />
           ))}
+
           {participants.map(({ id, audioTracks }) => (
             <AudioTracks audioTracks={audioTracks} key={id} />
           ))}

--- a/examples/react-client/videoroom/src/components/BlurToggle.tsx
+++ b/examples/react-client/videoroom/src/components/BlurToggle.tsx
@@ -36,7 +36,11 @@ export function BlurToggle() {
   const title = isMiddlewareSet ? "Clear blur" : "Blur camera";
 
   return (
-    <Button className="w-full" disabled={!camera.trackId} onClick={onClick}>
+    <Button
+      className="w-full"
+      disabled={!camera.streamedTrack}
+      onClick={onClick}
+    >
       {title}
     </Button>
   );

--- a/examples/react-client/videoroom/src/components/BlurToggle.tsx
+++ b/examples/react-client/videoroom/src/components/BlurToggle.tsx
@@ -36,11 +36,7 @@ export function BlurToggle() {
   const title = isMiddlewareSet ? "Clear blur" : "Blur camera";
 
   return (
-    <Button
-      className="w-full"
-      disabled={!camera.getCurrentTrack()?.trackId}
-      onClick={onClick}
-    >
+    <Button className="w-full" disabled={!camera.trackId} onClick={onClick}>
       {title}
     </Button>
   );

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -2,10 +2,9 @@ import { FC } from "react";
 import AudioVisualizer from "./AudioVisualizer";
 import VideoPlayer from "./VideoPlayer";
 import {
-  TrackManager,
+  Device,
   useCamera,
   useMicrophone,
-  UserMediaAPI,
   useScreenShare,
   useStatus,
 } from "@fishjam-cloud/react-client";
@@ -13,18 +12,18 @@ import { Button } from "./Button";
 import { BlurToggle } from "./BlurToggle";
 
 interface DeviceSelectProps {
-  device: UserMediaAPI & TrackManager;
+  device: Device;
 }
 
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
   const hasJoinedRoom = useStatus() === "joined";
 
-  const isTrackStreamed = !!device.getCurrentTrack()?.trackId;
+  const isTrackStreamed = !!device.trackId;
 
   return (
-    <div className="flex gap-4 justify-between">
+    <div className="flex justify-between gap-4">
       <select
-        className="flex-shrink w-full"
+        className="w-full flex-shrink"
         onChange={(e) => device.initialize(e.target.value)}
       >
         {device.devices?.map((device) => (

--- a/examples/react-client/videoroom/src/components/DevicePicker.tsx
+++ b/examples/react-client/videoroom/src/components/DevicePicker.tsx
@@ -18,7 +18,7 @@ interface DeviceSelectProps {
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
   const hasJoinedRoom = useStatus() === "joined";
 
-  const isTrackStreamed = !!device.trackId;
+  const isTrackStreamed = !!device.streamedTrack;
 
   return (
     <div className="flex justify-between gap-4">

--- a/examples/react-client/videoroom/src/components/RoomConnector.tsx
+++ b/examples/react-client/videoroom/src/components/RoomConnector.tsx
@@ -3,15 +3,15 @@ import {
   useDisconnect,
   useStatus,
 } from "@fishjam-cloud/react-client";
-
 import { Button } from "./Button";
+
 type FormProps = {
   roomName: string;
   userName: string;
   roomManagerUrl: string;
 };
 
-function psersistValues({ roomManagerUrl, roomName, userName }: FormProps) {
+function persistValues({ roomManagerUrl, roomName, userName }: FormProps) {
   localStorage.setItem("roomManagerUrl", roomManagerUrl);
   localStorage.setItem("roomName", roomName);
   localStorage.setItem("userName", userName);
@@ -68,7 +68,7 @@ export function RoomConnector() {
     const formData = new FormData(e.currentTarget);
     const formProps = Object.fromEntries(formData) as FormProps;
 
-    psersistValues(formProps);
+    persistValues(formProps);
 
     await connectToRoom(formProps);
   };
@@ -79,7 +79,7 @@ export function RoomConnector() {
       onSubmit={handleSubmit}
       autoComplete="on"
     >
-      <div className="flex flex-col  justify-between">
+      <div className="flex flex-col justify-between">
         <label htmlFor="roomManagerUrl">Room URL</label>
         <input
           id="roomManagerUrl"
@@ -101,7 +101,7 @@ export function RoomConnector() {
         />
       </div>
 
-      <div className="flex flex-col  justify-between">
+      <div className="flex flex-col justify-between">
         <label htmlFor="userName">User name</label>
         <input
           id="userName"

--- a/packages/react-client/src/hooks/devices.ts
+++ b/packages/react-client/src/hooks/devices.ts
@@ -1,12 +1,33 @@
 import { useFishjamContext } from "./fishjamContext";
-import type { UserMediaAPI, TrackManager } from "../types";
+import type { Device, AudioDevice } from "../types";
 
-export function useCamera(): UserMediaAPI & TrackManager {
-  const { state, videoTrackManager } = useFishjamContext();
-  return { ...state.devices.camera, ...videoTrackManager };
+export function useCamera(): Device {
+  const {
+    state,
+    videoTrackManager: { currentTrack, ...trackManager },
+  } = useFishjamContext();
+
+  const streamedTrackId = currentTrack?.trackId ?? null;
+  const streamedTrack = currentTrack?.track ?? null;
+  const stream = currentTrack?.stream ?? null;
+  const devices = state.devices.camera.devices ?? [];
+  const activeDevice = state.devices.camera.deviceInfo;
+
+  return { ...trackManager, streamedTrack, streamedTrackId, stream, devices, activeDevice };
 }
 
-export function useMicrophone(): UserMediaAPI & TrackManager {
-  const { state, audioTrackManager } = useFishjamContext();
-  return { ...state.devices.microphone, ...audioTrackManager };
+export function useMicrophone(): AudioDevice {
+  const {
+    state,
+    audioTrackManager: { currentTrack, ...trackManager },
+  } = useFishjamContext();
+
+  const isAudioPlaying = currentTrack?.vadStatus === "speech";
+  const streamedTrackId = currentTrack?.trackId ?? null;
+  const streamedTrack = currentTrack?.track ?? null;
+  const stream = currentTrack?.stream ?? null;
+  const devices = state.devices.microphone.devices ?? [];
+  const activeDevice = state.devices.microphone.deviceInfo;
+
+  return { ...trackManager, streamedTrack, streamedTrackId, isAudioPlaying, stream, devices, activeDevice };
 }

--- a/packages/react-client/src/hooks/participants.ts
+++ b/packages/react-client/src/hooks/participants.ts
@@ -15,7 +15,6 @@ export function useParticipants() {
   const { state } = useFishjamContext();
 
   const localParticipant = state.local ? getPeerWithDistinguishedTracks(state.local) : null;
-
   const participants = Object.values(state.remote).map(getPeerWithDistinguishedTracks);
 
   return { localParticipant, participants };

--- a/packages/react-client/src/hooks/setupMedia.ts
+++ b/packages/react-client/src/hooks/setupMedia.ts
@@ -38,7 +38,7 @@ export const useSetupMedia = (config: UseSetupMediaConfig): UseSetupMediaResult 
     const broadcastOnCameraStart = async (client: ClientApi) => {
       const config = configRef.current.camera;
       const onDeviceChange = config.onDeviceChange ?? "replace";
-      const stream = videoTrackManager.getCurrentTrack()?.stream;
+      const stream = videoTrackManager.currentTrack?.stream;
 
       if (isBroadcastedTrackChanged(client, pending)) {
         if (!stream && config.broadcastOnDeviceStart) {
@@ -96,7 +96,7 @@ export const useSetupMedia = (config: UseSetupMediaConfig): UseSetupMediaResult 
 
   useEffect(() => {
     const removeOnCameraStopped: ClientEvents["deviceStopped"] = async (event, client) => {
-      const stream = videoTrackManager.getCurrentTrack()?.stream;
+      const stream = videoTrackManager.currentTrack?.stream;
       const onDeviceStop = configRef.current.camera.onDeviceStop ?? "mute";
 
       if (
@@ -141,7 +141,7 @@ export const useSetupMedia = (config: UseSetupMediaConfig): UseSetupMediaResult 
     let pending = false;
 
     const broadcastOnMicrophoneStart = async (client: ClientApi) => {
-      const stream = audioTrackManager.getCurrentTrack()?.stream;
+      const stream = audioTrackManager.currentTrack?.stream;
       const config = configRef.current.microphone;
       const onDeviceChange = config.onDeviceChange ?? "replace";
 
@@ -199,7 +199,7 @@ export const useSetupMedia = (config: UseSetupMediaConfig): UseSetupMediaResult 
 
   useEffect(() => {
     const onMicrophoneStopped: ClientEvents["deviceStopped"] = async (event, client) => {
-      const stream = audioTrackManager.getCurrentTrack()?.stream;
+      const stream = audioTrackManager.currentTrack?.stream;
       const onDeviceStop = configRef.current.microphone.onDeviceStop ?? "mute";
       const isRightDeviceType = event.mediaDeviceType === "userMedia";
       const isRightTrackType = event.trackType === "audio";

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -22,14 +22,14 @@ export type {
   Participiants,
   StorageConfig,
   Devices,
-  UserMediaAPI,
+  Device,
+  AudioDevice,
   UseSetupMediaResult,
   UseSetupMediaConfig,
   CreateFishjamClient,
   ScreenshareApi,
   UseConnect,
   ConnectConfig,
-  TrackManager,
   TrackMiddleware,
   TrackMetadata, // only for compatibility reasons, will be removed in: FCE-415
   PeerMetadata, // only for compatibility reasons, will be removed in: FCE-415

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -2,7 +2,7 @@ import type { FishjamClient, SimulcastConfig, TrackBandwidthLimit } from "@fishj
 import type { MediaManager, PeerMetadata, TrackManager, TrackMetadata, TrackMiddleware } from "./types";
 import type { Track } from "./state.types";
 import { getRemoteOrLocalTrack } from "./utils/track";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
 interface TrackManagerConfig {
   mediaManager: MediaManager;
@@ -34,6 +34,8 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
     };
   }, [tsClient]);
 
+  const currentTrack = useMemo(() => getRemoteOrLocalTrack(tsClient, currentTrackId), [tsClient, currentTrackId]);
+
   function getPreviousTrack(): Track {
     if (!currentTrackId) throw Error("There is no current track id");
 
@@ -45,7 +47,6 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
   }
 
   async function setTrackMiddleware(middleware: TrackMiddleware): Promise<void> {
-    const currentTrack = getCurrentTrack();
     const mediaTrack = mediaManager.getTracks()[0];
 
     if (!currentTrack || !mediaTrack) return;
@@ -54,10 +55,6 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
     await tsClient.replaceTrack(currentTrack.trackId, trackToSet);
 
     setCurrentTrackMiddleware(() => middleware);
-  }
-
-  function getCurrentTrack(): Track | null {
-    return getRemoteOrLocalTrack(tsClient, currentTrackId);
   }
 
   function initialize(deviceId?: string) {
@@ -141,7 +138,7 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
   }
 
   return {
-    getCurrentTrack,
+    currentTrack,
     setTrackMiddleware,
     initialize,
     stop,

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -171,6 +171,16 @@ export type ScreenshareState = {
   tracksMiddleware?: TracksMiddleware | null;
 } | null;
 
+export type Device = {
+  streamedTrack: MediaStreamTrack | null;
+  streamedTrackId: TrackId | null;
+  stream: MediaStream | null;
+  devices: MediaDeviceInfo[];
+  activeDevice: MediaDeviceInfo | null;
+} & Omit<TrackManager, "currentTrack">;
+
+export type AudioDevice = Device & { isAudioPlaying: boolean };
+
 export interface TrackManager {
   initialize: (deviceId?: string) => Promise<void>;
   stop: () => Promise<void>;
@@ -184,7 +194,7 @@ export interface TrackManager {
   setTrackMiddleware: (middleware: TrackMiddleware) => Promise<void>;
   currentTrackMiddleware: TrackMiddleware;
   refreshStreamedTrack: () => Promise<void>;
-  getCurrentTrack: () => Track | null;
+  currentTrack: Track | null;
 }
 
 export type UserMediaAPI = {
@@ -196,11 +206,6 @@ export type UserMediaAPI = {
   deviceInfo: MediaDeviceInfo | null;
   error: DeviceError | null;
   devices: MediaDeviceInfo[] | null;
-};
-
-export type TrackManagerState = {
-  currentTrackId: TrackId | null;
-  currentTrackMiddleware: TrackMiddleware;
 };
 
 export type ScreenshareApi = {


### PR DESCRIPTION
## Description

This PR introduces slimmed-down version of the Device API.

## Motivation and Context

We acknowledged the currently exposed Device API is slightly too complicated.
This is a proposal of a simpler one.

```
export type Device = {
  streamedTrack: MediaStreamTrack | null;
  streamedTrackId: TrackId | null;
  stream: MediaStream | null;
  devices: MediaDeviceInfo[];
  activeDevice: MediaDeviceInfo | null;
} & Omit<TrackManager, "currentTrack">;

export type AudioDevice = Device & { isAudioPlaying: boolean };

export interface TrackManager {
  initialize: (deviceId?: string) => Promise<void>;
  stop: () => Promise<void>;
  startStreaming: (simulcastConfig?: SimulcastConfig, maxBandwidth?: TrackBandwidthLimit) => Promise<string>;
  stopStreaming: () => Promise<void>;
  pauseStreaming: () => Promise<void>;
  resumeStreaming: () => Promise<void>;
  paused: boolean;
  disableTrack: () => void;
  enableTrack: () => void;
  setTrackMiddleware: (middleware: TrackMiddleware) => Promise<void>;
  currentTrackMiddleware: TrackMiddleware;
  refreshStreamedTrack: () => Promise<void>;
  currentTrack: Track | null;
}
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
