### PR TITLE
add displayname track metadata

### DIFF
--- a/packages/react-client/src/hooks/screenShare.ts
+++ b/packages/react-client/src/hooks/screenShare.ts
@@ -16,15 +16,20 @@ export const useScreenShare = (): ScreenshareApi => {
   const [state, setState] = ctx.screenshareState;
   const tsClient = ctx.state.client.getTsClient();
 
+  const getDisplayName = () => tsClient.getLocalPeer()?.metadata?.displayName ?? "Unknown";
+
   const startStreaming: ScreenshareApi["startStreaming"] = async (props) => {
     const stream = await navigator.mediaDevices.getDisplayMedia({
       video: props?.videoConstraints ?? true,
       audio: props?.audioConstraints ?? true,
     });
-    const [video, audio] = getTracks(stream);
 
-    const addTrackPromises = [tsClient.addTrack(video)];
-    if (audio) addTrackPromises.push(tsClient.addTrack(audio));
+    const displayName = getDisplayName();
+
+    const [video, audio] = getTracks(stream);
+    const addTrackPromises = [tsClient.addTrack(video, { displayName, type: "screenShareVideo", paused: false })];
+    if (audio)
+      addTrackPromises.push(tsClient.addTrack(audio, { displayName, type: "screenShareAudio", paused: false }));
 
     const [videoId, audioId] = await Promise.all(addTrackPromises);
     setState({ stream, trackIds: { videoId, audioId } });

--- a/packages/react-client/src/hooks/screenShare.ts
+++ b/packages/react-client/src/hooks/screenShare.ts
@@ -16,7 +16,7 @@ export const useScreenShare = (): ScreenshareApi => {
   const [state, setState] = ctx.screenshareState;
   const tsClient = ctx.state.client.getTsClient();
 
-  const getDisplayName = () => tsClient.getLocalPeer()?.metadata?.displayName ?? "Unknown";
+  const getDisplayName = () => tsClient.getLocalPeer()?.metadata?.displayName;
 
   const startStreaming: ScreenshareApi["startStreaming"] = async (props) => {
     const stream = await navigator.mediaDevices.getDisplayMedia({

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -79,7 +79,9 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
     // see `getRemoteOrLocalTrackContext()` explanation
     setCurrentTrackId(media.track.id);
 
-    const trackMetadata: TrackMetadata = { ...metadata, paused: false };
+    const displayName = tsClient.getLocalPeer()?.metadata?.displayName ?? "Unknown";
+
+    const trackMetadata: TrackMetadata = { ...metadata, displayName, paused: false };
 
     const remoteTrackId = await tsClient.addTrack(media.track, trackMetadata, simulcastConfig, maxBandwidth);
 

--- a/packages/react-client/src/trackManager.ts
+++ b/packages/react-client/src/trackManager.ts
@@ -79,7 +79,7 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
     // see `getRemoteOrLocalTrackContext()` explanation
     setCurrentTrackId(media.track.id);
 
-    const displayName = tsClient.getLocalPeer()?.metadata?.displayName ?? "Unknown";
+    const displayName = tsClient.getLocalPeer()?.metadata?.displayName;
 
     const trackMetadata: TrackMetadata = { ...metadata, displayName, paused: false };
 


### PR DESCRIPTION
## Description

Populate track metadata `displayName` using peer metadata `displayName`.

## Motivation and Context

Recorder requires the `displayName` metadata property to handle the composition with labels.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
