### PR TITLE
Fce 464/simplify use initialize devices

### DIFF
--- a/examples/react-client/fishjam-chat/src/App.tsx
+++ b/examples/react-client/fishjam-chat/src/App.tsx
@@ -6,11 +6,16 @@ import {
   useInitializeDevices,
   useParticipants,
 } from "@fishjam-cloud/react-client";
+import { useEffect } from "react";
 
 function App() {
   const { localParticipant, participants } = useParticipants();
 
-  useInitializeDevices({ autoInitialize: true });
+  const { initializeDevices } = useInitializeDevices();
+
+  useEffect(() => {
+    initializeDevices();
+  }, [initializeDevices]);
 
   return (
     <main className="flex h-screen w-screen">

--- a/packages/react-client/src/hooks/useDevices.ts
+++ b/packages/react-client/src/hooks/useDevices.ts
@@ -38,9 +38,7 @@ export function useMicrophone(): AudioDevice {
   return { ...trackManager, ...getDeviceProperties(currentTrack, deviceState), isAudioPlaying };
 }
 
-type InitializeDevicesProps = { autoInitialize?: boolean };
-
-export const useInitializeDevices = (props?: InitializeDevicesProps) => {
+export const useInitializeDevices = () => {
   const { videoDeviceManagerRef, audioDeviceManagerRef, hasDevicesBeenInitializedRef } = useFishjamContext();
 
   const initializeDevices = useCallback(async () => {
@@ -85,13 +83,6 @@ export const useInitializeDevices = (props?: InitializeDevicesProps) => {
     );
     hasDevicesBeenInitializedRef.current = true;
   }, [videoDeviceManagerRef, audioDeviceManagerRef, hasDevicesBeenInitializedRef]);
-
-  const autoInitialize = Boolean(props?.autoInitialize);
-
-  useEffect(() => {
-    if (!autoInitialize) return;
-    initializeDevices();
-  }, [initializeDevices, autoInitialize]);
 
   return { initializeDevices };
 };

--- a/packages/react-client/src/hooks/useDevices.ts
+++ b/packages/react-client/src/hooks/useDevices.ts
@@ -2,7 +2,7 @@ import { useFishjamContext } from "./useFishjamContext";
 import type { Device, AudioDevice, DeviceState } from "../types";
 import { useVideoDeviceManager } from "./deviceManagers/useVideoDeviceManager";
 import { useAudioDeviceManager } from "./deviceManagers/useAudioDeviceManager";
-import { useCallback, useEffect } from "react";
+import { useCallback } from "react";
 import { getAvailableMedia, getCorrectedResult } from "../mediaInitializer";
 import type { Track } from "../state.types";
 


### PR DESCRIPTION
## Description
I discussed the `useInitializeDevices` magic behavior with Tommy.
Alike Miron, Tommy also showed his fondness towards the simpler and less magical approach.
I decided to remove the props and keep the hook dead simple.

## Types of changes

- [x] API polishing
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
