### PR TITLE
Allow connection to locally running room manager

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
@@ -44,8 +44,17 @@ export function RoomConnector() {
     // in case user copied url from the main Fishjam Cloud panel
     url = url.replace("/*roomName*/users/*username*", "");
     url = ensureUrlEndsWith(url, "/");
+
     // in case user copied url from the Fishjam Cloud App view
-    url = ensureUrlEndsWith(url, "room-manager/");
+    if (url.includes("/api/v1/connect/")) {
+      url = ensureUrlEndsWith(url, "room-manager/");
+    }
+
+    // in case user started room manager locally
+    // and provide only host (localhost:5004) or origin (http://localhost:5004)
+    if (new URL(url).pathname === "/") {
+      url = ensureUrlEndsWith(url, "api/rooms/");
+    }
 
     const res = await fetch(`${url}${roomName}/users/${userName}`);
 


### PR DESCRIPTION
## Description

Allow user to connect to locally running room manager.

## Motivation and Context

I wasn't able to connect to my local room manager instance because the string `room-manager/` was always added to the end of every URL.

## Types of changes

Bug fix (non-breaking change which fixes an issue)