### PR TITLE
FCE 410 Add toggle function

### DIFF
--- a/examples/react-client/fishjam-chat/src/App.tsx
+++ b/examples/react-client/fishjam-chat/src/App.tsx
@@ -43,6 +43,7 @@ function App() {
           {participants.map(
             ({ id, cameraTracks, screenshareVideoTracks, metadata }) => (
               <VideoTracks
+                key={id}
                 videoTracks={[...cameraTracks, ...screenshareVideoTracks]}
                 name={(metadata as { name?: string })?.name ?? id}
                 id={id}

--- a/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
@@ -77,15 +77,17 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
           onClick={async () => {
             await device.toggle();
           }}
+          title="Stops and starts the physical device"
         >
-          toggle
+          Toggle Device
         </Button>
         <Button
           onClick={async () => {
             await device.toggle("soft");
           }}
+          title="Disables or enables the device. Starts the device if it is stopped"
         >
-          soft toggle
+          Toggle Device (soft)
         </Button>
       </div>
     </div>

--- a/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
@@ -73,6 +73,22 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
           </Button>
         )}
       </div>
+      <div className="flex justify-between">
+        <Button
+          onClick={async () => {
+            await device.toggle();
+          }}
+        >
+          toggle("turnOff")
+        </Button>
+        <Button
+          onClick={async () => {
+            await device.toggle("soft");
+          }}
+        >
+          toggle("suspend")
+        </Button>
+      </div>
     </div>
   );
 };

--- a/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
@@ -45,7 +45,7 @@ export function RoomConnector() {
     url = url.replace("/*roomName*/users/*username*", "");
     url = ensureUrlEndsWith(url, "/");
     // in case user copied url from the Fishjam Cloud App view
-    url = ensureUrlEndsWith(url, "room-manager/");
+    // url = ensureUrlEndsWith(url, "room-manager/");
 
     const res = await fetch(`${url}${roomName}/users/${userName}`);
 

--- a/examples/react-client/fishjam-chat/src/components/VideoTracks.tsx
+++ b/examples/react-client/fishjam-chat/src/components/VideoTracks.tsx
@@ -16,7 +16,6 @@ export function VideoTracks({ videoTracks, name, id }: Props) {
       {videoTrack && (
         <VideoPlayer
           className="rounded-md z-20"
-          key={videoTrack.trackId}
           stream={videoTrack.stream}
           peerId={id}
         />

--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -19,18 +19,18 @@ export function FishjamProvider({ children, config, deviceManagerDefaultConfig }
   const audioDeviceManagerRef = useRef(new DeviceManager("audio", deviceManagerDefaultConfig));
 
   const screenshareState = useState<ScreenshareState>({ stream: null, trackIds: null });
-  const { peerStatus, getCurrentPeerState } = usePeerStatus(fishjamClientRef.current);
+  const { peerStatus, getCurrentPeerStatus } = usePeerStatus(fishjamClientRef.current);
 
   const videoTrackManager = useTrackManager({
     mediaManager: videoDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
-    getCurrentPeerState,
+    getCurrentPeerStatus,
   });
 
   const audioTrackManager = useTrackManager({
     mediaManager: audioDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
-    getCurrentPeerState,
+    getCurrentPeerStatus,
   });
 
   const context = {

--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -19,21 +19,23 @@ export function FishjamProvider({ children, config, deviceManagerDefaultConfig }
   const audioDeviceManagerRef = useRef(new DeviceManager("audio", deviceManagerDefaultConfig));
 
   const screenshareState = useState<ScreenshareState>(null);
-  const peerStatusState = usePeerStatus(fishjamClientRef.current);
+  const { peerStatus, getCurrentPeerState } = usePeerStatus(fishjamClientRef.current);
 
   const videoTrackManager = useTrackManager({
     mediaManager: videoDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
+    getCurrentPeerState,
   });
 
   const audioTrackManager = useTrackManager({
     mediaManager: audioDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
+    getCurrentPeerState
   });
 
   const context = {
     fishjamClientRef,
-    peerStatusState,
+    peerStatus,
     screenshareState,
     videoTrackManager,
     audioTrackManager,

--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -30,7 +30,7 @@ export function FishjamProvider({ children, config, deviceManagerDefaultConfig }
   const audioTrackManager = useTrackManager({
     mediaManager: audioDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
-    getCurrentPeerState
+    getCurrentPeerState,
   });
 
   const context = {

--- a/packages/react-client/src/hooks/useFishjamClient.ts
+++ b/packages/react-client/src/hooks/useFishjamClient.ts
@@ -99,8 +99,7 @@ This is an internally used hook.
 It is not meant to be used by the end user.
 */
 export const useFishjamClient_DO_NOT_USE = () => {
-  const { fishjamClientRef, peerStatusState } = useFishjamContext();
-  const [peerStatus, setPeerStatus] = peerStatusState;
+  const { fishjamClientRef, peerStatus } = useFishjamContext();
 
   const client = useMemo(() => fishjamClientRef.current, [fishjamClientRef]);
   const mutationRef = useRef(false);
@@ -152,7 +151,6 @@ export const useFishjamClient_DO_NOT_USE = () => {
   }
 
   function connect(config: ConnectConfig) {
-    setPeerStatus("connecting");
     return client.connect({ ...config, peerMetadata: config?.peerMetadata ?? {} });
   }
 

--- a/packages/react-client/src/hooks/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/useFishjamContext.ts
@@ -10,7 +10,7 @@ export type FishjamContextType = {
   audioDeviceManagerRef: MutableRefObject<DeviceManager>;
   hasDevicesBeenInitializedRef: MutableRefObject<boolean>;
   screenshareState: [ScreenshareState, React.Dispatch<React.SetStateAction<ScreenshareState>>];
-  peerStatus: PeerStatus,
+  peerStatus: PeerStatus;
   videoTrackManager: TrackManager;
   audioTrackManager: TrackManager;
 };

--- a/packages/react-client/src/hooks/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/useFishjamContext.ts
@@ -10,7 +10,7 @@ export type FishjamContextType = {
   audioDeviceManagerRef: MutableRefObject<DeviceManager>;
   hasDevicesBeenInitializedRef: MutableRefObject<boolean>;
   screenshareState: [ScreenshareState, React.Dispatch<React.SetStateAction<ScreenshareState>>];
-  peerStatusState: readonly [PeerStatus, React.Dispatch<React.SetStateAction<PeerStatus>>];
+  peerStatus: PeerStatus,
   videoTrackManager: TrackManager;
   audioTrackManager: TrackManager;
 };

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -7,10 +7,13 @@ export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>
   const [peerStatus, setPeerStatus] = useState<PeerStatus>(null);
   const peerStatusRef = useRef<PeerStatus>(null);
 
-  const setInnerStatus = useCallback((status: PeerStatus) => {
-    peerStatusRef.current = status
-    setPeerStatus(status)
-  }, [setPeerStatus]);
+  const setInnerStatus = useCallback(
+    (status: PeerStatus) => {
+      peerStatusRef.current = status;
+      setPeerStatus(status);
+    },
+    [setPeerStatus],
+  );
 
   const getCurrentPeerState = useCallback(() => peerStatusRef.current, []);
 

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -4,37 +4,37 @@ import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import type { PeerMetadata, TrackMetadata } from "../types";
 
 export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>) => {
-  const [peerStatus, setPeerStatus] = useState<PeerStatus>(null);
+  const [peerStatus, setPeerStatusState] = useState<PeerStatus>(null);
   const peerStatusRef = useRef<PeerStatus>(null);
 
-  const setInnerStatus = useCallback(
+  const setPeerStatus = useCallback(
     (status: PeerStatus) => {
       peerStatusRef.current = status;
-      setPeerStatus(status);
+      setPeerStatusState(status);
     },
-    [setPeerStatus],
+    [setPeerStatusState],
   );
 
   const getCurrentPeerState = useCallback(() => peerStatusRef.current, []);
 
   useEffect(() => {
     const setConnecting = () => {
-      setInnerStatus("connecting");
+      setPeerStatus("connecting");
     };
     const setAuthenticated = () => {
-      setInnerStatus("authenticated");
+      setPeerStatus("authenticated");
     };
     const setError = () => {
-      setInnerStatus("error");
+      setPeerStatus("error");
     };
     const setJoined = () => {
-      setInnerStatus("joined");
+      setPeerStatus("joined");
     };
     const setDisconnected = () => {
-      setInnerStatus(null);
+      setPeerStatus(null);
     };
     const setConnected = () => {
-      setInnerStatus("connected");
+      setPeerStatus("connected");
     };
 
     client.on("connectionStarted", setConnecting);
@@ -56,7 +56,7 @@ export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>
       client.off("disconnected", setDisconnected);
       client.off("socketOpen", setConnected);
     };
-  }, [client, setInnerStatus]);
+  }, [client, setPeerStatus]);
 
   return { peerStatus, getCurrentPeerState } as const;
 };

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -15,7 +15,7 @@ export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>
     [setPeerStatusState],
   );
 
-  const getCurrentPeerState = useCallback(() => peerStatusRef.current, []);
+  const getCurrentPeerStatus = useCallback(() => peerStatusRef.current, []);
 
   useEffect(() => {
     const setConnecting = () => {
@@ -58,5 +58,5 @@ export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>
     };
   }, [client, setPeerStatus]);
 
-  return { peerStatus, getCurrentPeerState } as const;
+  return { peerStatus, getCurrentPeerStatus } as const;
 };

--- a/packages/react-client/src/hooks/useStatus.ts
+++ b/packages/react-client/src/hooks/useStatus.ts
@@ -1,9 +1,5 @@
 import { useFishjamContext } from "./useFishjamContext";
 
 export function useStatus() {
-  const {
-    peerStatusState: [peerStatus],
-  } = useFishjamContext();
-
-  return peerStatus;
+  return useFishjamContext().peerStatus;
 }

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -153,7 +153,7 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
 
   async function toggle(mode: ToggleMode = "hard") {
     const mediaStream = mediaManager.getMedia()?.stream;
-    const track = mediaManager.getTracks()?.[0]
+    const track = mediaManager.getTracks()?.[0];
     const enabled = Boolean(track?.enabled);
 
     if (mediaStream && enabled) {

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -7,7 +7,7 @@ import type { PeerStatus } from "../state.types";
 interface TrackManagerConfig {
   mediaManager: MediaManager;
   tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
-  getCurrentPeerState: () => PeerStatus;
+  getCurrentPeerStatus: () => PeerStatus;
 }
 
 const TRACK_TYPE_TO_DEVICE = {
@@ -15,7 +15,7 @@ const TRACK_TYPE_TO_DEVICE = {
   audio: "microphone",
 } as const;
 
-export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerState }: TrackManagerConfig): TrackManager => {
+export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerStatus }: TrackManagerConfig): TrackManager => {
   const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
   const [paused, setPaused] = useState<boolean>(false);
   const clearMiddlewareFnRef = useRef<(() => void) | null>(null);
@@ -153,7 +153,7 @@ export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerState }:
   }
 
   const stream = async () => {
-    if (getCurrentPeerState() !== "joined") return;
+    if (getCurrentPeerStatus() !== "joined") return;
 
     if (currentTrack?.trackId) {
       await resumeStreaming();

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -7,7 +7,7 @@ import type { PeerStatus } from "../state.types";
 interface TrackManagerConfig {
   mediaManager: MediaManager;
   tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
-  getCurrentPeerState: () => PeerStatus
+  getCurrentPeerState: () => PeerStatus;
 }
 
 const TRACK_TYPE_TO_DEVICE = {

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -153,10 +153,7 @@ export const useTrackManager = ({ mediaManager, tsClient }: TrackManagerConfig):
 
   async function toggle(mode: ToggleMode = "hard") {
     const mediaStream = mediaManager.getMedia()?.stream;
-    const track =
-      mediaManager.getDeviceType() === "video"
-        ? mediaStream?.getVideoTracks()?.[0]
-        : mediaStream?.getAudioTracks()?.[0];
+    const track = mediaManager.getTracks()?.[0]
     const enabled = Boolean(track?.enabled);
 
     if (mediaStream && enabled) {

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -162,6 +162,9 @@ export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerStatus }
     }
   };
 
+  /**
+   * @see {@link TrackManager#toggle} for more details.
+   */
   async function toggle(mode: ToggleMode = "hard") {
     const mediaStream = mediaManager.getMedia()?.stream;
     const track = mediaManager.getTracks()?.[0];

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -199,6 +199,22 @@ export interface TrackManager {
   currentTrackMiddleware: TrackMiddleware;
   refreshStreamedTrack: () => Promise<void>;
   currentTrack: Track | null;
+
+  /**
+   * Toggles the media stream state based on the provided mode.
+   * Either initiates or terminates the device or enables or disables the stream.
+   *
+   * @param {ToggleMode} [mode] - The toggle mode, either "hard" or "soft". Defaults to "hard".
+   *
+   * - **Hard Mode** - Turns the physical device on and off.
+   *   - If started: disables the media stream, pauses streaming, and stops the device.
+   *   - If stopped: starts the device and begins (or resumes) streaming.
+   *
+   * - **Soft Mode** - Enables and disables the media stream. Starts the device if needed.
+   *   - If enabled: disables the media stream and pauses streaming, but does not stop the device.
+   *   - If disabled: enables the media stream and starts (or resumes) streaming.
+   *   - If stopped: starts the device, enables the media stream, and starts (or resumes) streaming.
+   */
   toggle: (mode?: ToggleMode) => Promise<void>;
 }
 

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -178,6 +178,8 @@ export type Device = {
 
 export type AudioDevice = Device & { isAudioPlaying: boolean };
 
+export type ToggleMode = "soft" | "hard";
+
 export interface TrackManager {
   initialize: (deviceId?: string) => Promise<void>;
   stop: () => Promise<void>;
@@ -192,6 +194,7 @@ export interface TrackManager {
   currentTrackMiddleware: TrackMiddleware;
   refreshStreamedTrack: () => Promise<void>;
   currentTrack: Track | null;
+  toggle: (mode?: ToggleMode) => Promise<void>;
 }
 
 export type UserMediaAPI = {

--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -45,6 +45,12 @@ const WEBSOCKET_PATH = 'socket/peer/websocket';
  */
 export interface MessageEvents<PeerMetadata, TrackMetadata> {
   /**
+   * Emitted when connect method invoked
+   *
+   */
+  connectionStarted: () => void;
+
+  /**
    * Emitted when the websocket connection is closed
    *
    * @param {CloseEvent} event - Close event object from the websocket
@@ -315,6 +321,7 @@ export class FishjamClient<PeerMetadata, TrackMetadata> extends (EventEmitter as
    * @param {ConnectConfig} config - Configuration object for the client
    */
   connect(config: ConnectConfig<PeerMetadata>): void {
+    this.emit("connectionStarted")
     this.reconnectManager.reset(config.peerMetadata);
     this.connectConfig = config;
 

--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -321,7 +321,7 @@ export class FishjamClient<PeerMetadata, TrackMetadata> extends (EventEmitter as
    * @param {ConnectConfig} config - Configuration object for the client
    */
   connect(config: ConnectConfig<PeerMetadata>): void {
-    this.emit("connectionStarted")
+    this.emit('connectionStarted');
     this.reconnectManager.reset(config.peerMetadata);
     this.connectConfig = config;
 


### PR DESCRIPTION
## Description

The toggle function works in two modes: "soft" and "hard" (default). The user can invoke this function without any arguments. It starts (or resumes) the device and streams media if the user is connected. 

### `hard` 
- Turns off the device
- Slower start
- Turns off the device LED
- Example usage: camera

### `soft`
- Only disables the device
- Faster start
- The device LED remains active
- Example usage: microphone

## Motivation and Context

To unify the API with the Mobile SDK. It's important to implement this feature to avoid confusion:
https://linear.app/swmansion/issue/FCE-489/add-the-camera-and-mic-after-connecting-if-they-are-active-web

## Types of changes

New feature (non-breaking change which adds functionality)