### PR TITLE
FCE-460 Return a promise from the connect function

### DIFF
--- a/packages/react-client/src/hooks/useConnection.ts
+++ b/packages/react-client/src/hooks/useConnection.ts
@@ -1,18 +1,11 @@
 import type { UseConnect } from "../types";
-import { useCallback, useMemo } from "react";
+import { useCallback } from "react";
 import { useFishjamClient_DO_NOT_USE } from "./useFishjamClient";
 
 export function useConnect(): UseConnect {
   const client = useFishjamClient_DO_NOT_USE();
 
-  return useMemo(() => {
-    return (config) => {
-      client.connect(config);
-      return () => {
-        client.disconnect();
-      };
-    };
-  }, [client]);
+  return useCallback((config) => client.connect(config), [client]);
 }
 
 export function useDisconnect() {

--- a/packages/react-client/src/hooks/useFishjamClient.ts
+++ b/packages/react-client/src/hooks/useFishjamClient.ts
@@ -151,7 +151,7 @@ export const useFishjamClient_DO_NOT_USE = () => {
     return client.addTrack(track, undefined, simulcastConfig, maxBandwidth);
   }
 
-  function connect(config: ConnectConfig) {
+  function connect(config: ConnectConfig): Promise<void> {
     setPeerStatus("connecting");
     return client.connect({ ...config, peerMetadata: config?.peerMetadata ?? {} });
   }

--- a/packages/react-client/src/types.ts
+++ b/packages/react-client/src/types.ts
@@ -236,7 +236,7 @@ export type TracksMiddleware = (
 ) => { videoTrack: MediaStreamTrack; audioTrack: MediaStreamTrack | null; onClear: () => void };
 
 export type ConnectConfig = Omit<TSClientConnectConfig<PeerMetadata>, "peerMetadata"> & { peerMetadata?: PeerMetadata };
-export type UseConnect = (config: ConnectConfig) => () => void;
+export type UseConnect = (config: ConnectConfig) => Promise<void>;
 
 type DistinguishedTracks = {
   cameraTracks: Track[];

--- a/packages/ts-client/src/ConnectPromise.ts
+++ b/packages/ts-client/src/ConnectPromise.ts
@@ -1,0 +1,40 @@
+import { Deferred } from './webrtc/deferred';
+import type { FishjamClient } from './FishjamClient';
+
+export class ConnectPromise<P, T> {
+  private readonly result: Deferred<void>;
+  private readonly clearCallbacks: () => void;
+
+  constructor(fishjamClient: FishjamClient<P, T>) {
+    this.result = new Deferred<void>();
+
+    const onSuccess = () => {
+      this.result.resolve();
+    };
+    const onError = () => {
+      this.result.reject('joinError');
+    };
+
+    fishjamClient.on('joined', onSuccess);
+    fishjamClient.on('joinError', onError);
+    fishjamClient.on('authError', onError);
+    fishjamClient.on('socketError', onError);
+
+    this.clearCallbacks = () => {
+      fishjamClient.removeListener('joined', onSuccess);
+      fishjamClient.removeListener('joinError', onError);
+      fishjamClient.removeListener('authError', onError);
+      fishjamClient.removeListener('socketError', onError);
+    };
+  }
+
+  public async getPromise(): Promise<void> {
+    try {
+      // `await` is necessary in order to wait until the promise resolves or rejects.
+      // Without it, the finally section clears callbacks immediately.
+      return await this.result.promise;
+    } finally {
+      this.clearCallbacks();
+    }
+  }
+}

--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -17,6 +17,7 @@ import type { ReconnectConfig } from './reconnection';
 import { ReconnectManager } from './reconnection';
 import type { AuthErrorReason } from './auth';
 import { isAuthError } from './auth';
+import { ConnectPromise } from './ConnectPromise';
 
 const STATISTICS_INTERVAL = 10_000;
 
@@ -314,11 +315,15 @@ export class FishjamClient<PeerMetadata, TrackMetadata> extends (EventEmitter as
    *
    * @param {ConnectConfig} config - Configuration object for the client
    */
-  connect(config: ConnectConfig<PeerMetadata>): void {
+  public async connect(config: ConnectConfig<PeerMetadata>): Promise<void> {
+    const result = new ConnectPromise(this);
+
     this.reconnectManager.reset(config.peerMetadata);
     this.connectConfig = config;
 
     this.initConnection(config.peerMetadata);
+
+    return result.getPromise();
   }
 
   private async initConnection(peerMetadata: PeerMetadata): Promise<void> {


### PR DESCRIPTION
## Description

The connect function now returns a promise instead of a "disconnect" callback.

## Motivation and Context

This change allows users to implement custom logic upon connection instead of using the `joined` event.

## Types of changes

Breaking change (fix or feature that would cause existing functionality to not work as expected)
