### PR TITLE
FCE-543 Remove warn on every disconnect

### DIFF
--- a/packages/react-client/src/hooks/useScreenShare.ts
+++ b/packages/react-client/src/hooks/useScreenShare.ts
@@ -20,6 +20,9 @@ export const useScreenShare = (): ScreenshareApi => {
 
   const tsClient = fishjamClientRef.current;
 
+  const stream = state.stream ?? null;
+  const [videoTrack, audioTrack] = stream ? getTracks(stream) : [null, null];
+
   const getDisplayName = () => tsClient.getLocalPeer()?.metadata?.displayName;
 
   const startStreaming: ScreenshareApi["startStreaming"] = async (props) => {
@@ -120,17 +123,16 @@ export const useScreenShare = (): ScreenshareApi => {
   useEffect(() => {
     const client = fishjamClientRef.current;
     const onDisconnected = () => {
-      stopStreaming();
+      if (stream) {
+        stopStreaming();
+      }
     };
     client.on("disconnected", onDisconnected);
 
     return () => {
       client.removeListener("disconnected", onDisconnected);
     };
-  }, [stopStreaming, fishjamClientRef]);
-
-  const stream = state.stream ?? null;
-  const [videoTrack, audioTrack] = stream ? getTracks(stream) : [null, null];
+  }, [stopStreaming, fishjamClientRef, stream]);
 
   const videoBroadcast = state.stream ? getRemoteOrLocalTrack(tsClient, state.trackIds.videoId) : null;
   const audioBroadcast = state.trackIds?.audioId ? getRemoteOrLocalTrack(tsClient, state.trackIds.audioId) : null;


### PR DESCRIPTION
## Description

`stopStreaming()` on disconnect is only invoked if there is a screen share stream.

## Motivation and Context

There is no need to issue a warning about screen sharing on every disconnect.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
