### PR TITLE
FCE-458 Rename client statuses

### DIFF
--- a/e2e-tests/react-client/scenarios/utils.ts
+++ b/e2e-tests/react-client/scenarios/utils.ts
@@ -13,7 +13,7 @@ export const joinRoomAndAddScreenShare = async (page: Page, roomId: string): Pro
       await test.step("Join room", async () => {
         await page.getByPlaceholder("token").fill(peerToken);
         await page.getByRole("button", { name: "Connect", exact: true }).click();
-        await expect(page.getByText("Status: joined")).toBeVisible();
+        await expect(page.getByText("Status: connected")).toBeVisible();
       });
 
       await test.step("Add screenshare", async () => {

--- a/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
@@ -16,7 +16,7 @@ interface DeviceSelectProps {
 }
 
 const DeviceSelect: FC<DeviceSelectProps> = ({ device }) => {
-  const hasJoinedRoom = useStatus() === "joined";
+  const hasJoinedRoom = useStatus() === "connected";
 
   return (
     <div className="flex flex-col justify-between gap-4">
@@ -99,7 +99,7 @@ export function DevicePicker() {
   const microphone = useMicrophone();
 
   const screenShare = useScreenShare();
-  const hasJoinedRoom = useStatus() === "joined";
+  const hasJoinedRoom = useStatus() === "connected";
 
   return (
     <section className="space-y-8">

--- a/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
@@ -28,11 +28,9 @@ function getPersistedValues() {
 
 export function RoomConnector() {
   const connect = useConnect();
-  const status = useStatus();
+  const isUserConnected = useStatus() === "connected";
   const disconnect = useDisconnect();
   const [connectionError, setConnectionError] = useState<string | null>(null);
-
-  const isUserConnected = status === "joined";
 
   const connectToRoom = async ({
     roomManagerUrl,
@@ -132,11 +130,11 @@ export function RoomConnector() {
       </div>
 
       <div className="flex justify-end gap-4">
-        <Button onClick={disconnect} disabled={!status || !isUserConnected}>
+        <Button onClick={disconnect} disabled={!isUserConnected}>
           Disconnect
         </Button>
 
-        <Button type="submit" disabled={!!status || isUserConnected}>
+        <Button type="submit" disabled={isUserConnected}>
           Connect
         </Button>
       </div>

--- a/examples/react-client/minimal-react/src/components/App.tsx
+++ b/examples/react-client/minimal-react/src/components/App.tsx
@@ -35,7 +35,7 @@ export const App = () => {
       />
       <div style={{ display: "flex", flexDirection: "row", gap: "8px" }}>
         <button
-          disabled={token === "" || status === "joined"}
+          disabled={token === "" || status === "connected"}
           onClick={() => {
             if (!token || token === "") throw Error("Token is empty");
             connect({
@@ -47,7 +47,7 @@ export const App = () => {
           Connect
         </button>
         <button
-          disabled={status !== "joined"}
+          disabled={status !== "connected"}
           onClick={() => {
             disconnect();
           }}
@@ -55,7 +55,7 @@ export const App = () => {
           Disconnect
         </button>
         <button
-          disabled={status !== "joined"}
+          disabled={status !== "connected"}
           onClick={async () => {
             // stream video only
             screenShare.startStreaming({ audioConstraints: false });

--- a/examples/react-client/use-camera-and-microphone/src/Badge.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/Badge.tsx
@@ -6,13 +6,10 @@ type Props = {
 
 const getBadgeColor = (status: PeerStatus) => {
   switch (status) {
-    case "joined":
+    case "connected":
       return "badge-success";
     case "error":
       return "badge-error";
-    case "authenticated":
-    case "connected":
-      return "badge-info";
     case "connecting":
       return "badge-warning";
   }

--- a/examples/react-client/use-camera-and-microphone/src/Badge.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/Badge.tsx
@@ -1,10 +1,10 @@
-import type { PeerStatus } from "@fishjam-cloud/react-client";
+import type { ParticipantStatus } from "@fishjam-cloud/react-client";
 
 type Props = {
-  status: PeerStatus;
+  status: ParticipantStatus;
 };
 
-const getBadgeColor = (status: PeerStatus) => {
+const getBadgeColor = (status: ParticipantStatus) => {
   switch (status) {
     case "connected":
       return "badge-success";

--- a/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
@@ -1,11 +1,11 @@
 import type {
-  PeerStatus,
+  ParticipantStatus,
   Device,
   AudioDevice,
 } from "@fishjam-cloud/react-client";
 
 type DeviceControlsProps = {
-  status: PeerStatus;
+  status: ParticipantStatus;
 } & (
   | {
       device: AudioDevice;

--- a/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
@@ -66,7 +66,7 @@ export const DeviceControls = ({
 
       <button
         className="btn btn-success btn-sm"
-        disabled={status !== "joined" || device.isStreaming}
+        disabled={status !== "connected" || device.isStreaming}
         onClick={() => {
           device?.startStreaming();
         }}
@@ -76,7 +76,7 @@ export const DeviceControls = ({
 
       <button
         className="btn btn-error btn-sm"
-        disabled={status !== "joined" || !device.isStreaming}
+        disabled={status !== "connected" || !device.isStreaming}
         onClick={() => {
           device?.stopStreaming();
         }}

--- a/examples/react-client/use-camera-and-microphone/src/MainControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/MainControls.tsx
@@ -174,12 +174,7 @@ export const MainControls = () => {
 
           <button
             className="btn btn-success btn-sm"
-            disabled={
-              token === "" ||
-              status === "authenticated" ||
-              status === "connected" ||
-              status === "joined"
-            }
+            disabled={token === "" || status === "connected"}
             onClick={() => {
               if (!token || token === "") throw Error("Token is empty");
               connect({
@@ -193,12 +188,7 @@ export const MainControls = () => {
 
           <button
             className="btn btn-success btn-sm"
-            disabled={
-              token === "" ||
-              status === "authenticated" ||
-              status === "connected" ||
-              status === "joined"
-            }
+            disabled={token === ""}
             onClick={() => {
               if (!token || token === "") throw Error("Token is empty");
               disconnect();
@@ -214,9 +204,7 @@ export const MainControls = () => {
 
           <button
             className="btn btn-error btn-sm"
-            disabled={
-              status === null || status === "closed" || status === "error"
-            }
+            disabled={status !== "connected"}
             onClick={() => {
               disconnect();
             }}

--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -4,7 +4,7 @@ import type { DeviceManagerConfig, PeerMetadata, ScreenshareState, TrackMetadata
 import { FishjamClient, type ReconnectConfig } from "@fishjam-cloud/ts-client";
 import { FishjamContext } from "./hooks/useFishjamContext";
 import { DeviceManager } from "./DeviceManager";
-import { usePeerStatus } from "./hooks/usePeerStatus";
+import { useParticipantStatus } from "./hooks/useParticipantStatus";
 
 interface FishjamProviderProps extends PropsWithChildren {
   config?: { reconnect?: ReconnectConfig | boolean };
@@ -19,18 +19,18 @@ export function FishjamProvider({ children, config, deviceManagerDefaultConfig }
   const audioDeviceManagerRef = useRef(new DeviceManager("audio", deviceManagerDefaultConfig));
 
   const screenshareState = useState<ScreenshareState>({ stream: null, trackIds: null });
-  const { peerStatus, getCurrentPeerStatus } = usePeerStatus(fishjamClientRef.current);
+  const { peerStatus, getCurrentParticipantStatus } = useParticipantStatus(fishjamClientRef.current);
 
   const videoTrackManager = useTrackManager({
     mediaManager: videoDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
-    getCurrentPeerStatus,
+    getCurrentParticipantStatus,
   });
 
   const audioTrackManager = useTrackManager({
     mediaManager: audioDeviceManagerRef.current,
     tsClient: fishjamClientRef.current,
-    getCurrentPeerStatus,
+    getCurrentParticipantStatus,
   });
 
   const context = {

--- a/packages/react-client/src/hooks/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/useFishjamContext.ts
@@ -2,7 +2,7 @@ import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import { createContext, type MutableRefObject, useContext } from "react";
 import type { PeerMetadata, TrackMetadata, ScreenshareState, TrackManager } from "../types";
 import type { DeviceManager } from "../DeviceManager";
-import type { PeerStatus } from "../state.types";
+import type { ParticipantStatus } from "../state.types";
 
 export type FishjamContextType = {
   fishjamClientRef: MutableRefObject<FishjamClient<PeerMetadata, TrackMetadata>>;
@@ -10,7 +10,7 @@ export type FishjamContextType = {
   audioDeviceManagerRef: MutableRefObject<DeviceManager>;
   hasDevicesBeenInitializedRef: MutableRefObject<boolean>;
   screenshareState: [ScreenshareState, React.Dispatch<React.SetStateAction<ScreenshareState>>];
-  peerStatus: PeerStatus;
+  peerStatus: ParticipantStatus;
   videoTrackManager: TrackManager;
   audioTrackManager: TrackManager;
 };

--- a/packages/react-client/src/hooks/useParticipantStatus.ts
+++ b/packages/react-client/src/hooks/useParticipantStatus.ts
@@ -3,32 +3,32 @@ import type { ParticipantStatus } from "../state.types";
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import type { PeerMetadata, TrackMetadata } from "../types";
 
-export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>) => {
-  const [peerStatus, setPeerStatusState] = useState<ParticipantStatus>("idle");
+export const useParticipantStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>) => {
+  const [peerStatus, setParticipantStatusState] = useState<ParticipantStatus>("idle");
   const peerStatusRef = useRef<ParticipantStatus>("idle");
 
-  const setPeerStatus = useCallback(
+  const setParticipantStatus = useCallback(
     (status: ParticipantStatus) => {
       peerStatusRef.current = status;
-      setPeerStatusState(status);
+      setParticipantStatusState(status);
     },
-    [setPeerStatusState],
+    [setParticipantStatusState],
   );
 
-  const getCurrentPeerStatus = useCallback(() => peerStatusRef.current, []);
+  const getCurrentParticipantStatus = useCallback(() => peerStatusRef.current, []);
 
   useEffect(() => {
     const setConnecting = () => {
-      setPeerStatus("connecting");
+      setParticipantStatus("connecting");
     };
     const setError = () => {
-      setPeerStatus("error");
+      setParticipantStatus("error");
     };
     const setJoined = () => {
-      setPeerStatus("connected");
+      setParticipantStatus("connected");
     };
     const setDisconnected = () => {
-      setPeerStatus("idle");
+      setParticipantStatus("idle");
     };
 
     client.on("connectionStarted", setConnecting);
@@ -46,7 +46,7 @@ export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>
       client.off("connectionError", setError);
       client.off("disconnected", setDisconnected);
     };
-  }, [client, setPeerStatus]);
+  }, [client, setParticipantStatus]);
 
-  return { peerStatus, getCurrentPeerStatus } as const;
+  return { peerStatus, getCurrentParticipantStatus } as const;
 };

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -1,14 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { PeerStatus } from "../state.types";
+import type { ParticipantStatus } from "../state.types";
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import type { PeerMetadata, TrackMetadata } from "../types";
 
 export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>) => {
-  const [peerStatus, setPeerStatusState] = useState<PeerStatus>("idle");
-  const peerStatusRef = useRef<PeerStatus>("idle");
+  const [peerStatus, setPeerStatusState] = useState<ParticipantStatus>("idle");
+  const peerStatusRef = useRef<ParticipantStatus>("idle");
 
   const setPeerStatus = useCallback(
-    (status: PeerStatus) => {
+    (status: ParticipantStatus) => {
       peerStatusRef.current = status;
       setPeerStatusState(status);
     },

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -4,8 +4,8 @@ import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import type { PeerMetadata, TrackMetadata } from "../types";
 
 export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>) => {
-  const [peerStatus, setPeerStatusState] = useState<PeerStatus>(null);
-  const peerStatusRef = useRef<PeerStatus>(null);
+  const [peerStatus, setPeerStatusState] = useState<PeerStatus>("idle");
+  const peerStatusRef = useRef<PeerStatus>("idle");
 
   const setPeerStatus = useCallback(
     (status: PeerStatus) => {
@@ -21,40 +21,30 @@ export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>
     const setConnecting = () => {
       setPeerStatus("connecting");
     };
-    const setAuthenticated = () => {
-      setPeerStatus("authenticated");
-    };
     const setError = () => {
       setPeerStatus("error");
     };
     const setJoined = () => {
-      setPeerStatus("joined");
+      setPeerStatus("connected");
     };
     const setDisconnected = () => {
-      setPeerStatus(null);
-    };
-    const setConnected = () => {
-      setPeerStatus("connected");
+      setPeerStatus("idle");
     };
 
     client.on("connectionStarted", setConnecting);
-    client.on("authSuccess", setAuthenticated);
     client.on("joined", setJoined);
     client.on("authError", setError);
     client.on("joinError", setError);
     client.on("connectionError", setError);
     client.on("disconnected", setDisconnected);
-    client.on("socketOpen", setConnected);
 
     return () => {
       client.off("connectionStarted", setConnecting);
-      client.off("authSuccess", setAuthenticated);
       client.off("joined", setJoined);
       client.off("authError", setError);
       client.off("joinError", setError);
       client.off("connectionError", setError);
       client.off("disconnected", setDisconnected);
-      client.off("socketOpen", setConnected);
     };
   }, [client, setPeerStatus]);
 

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -2,12 +2,12 @@ import type { FishjamClient, SimulcastConfig, TrackBandwidthLimit } from "@fishj
 import type { MediaManager, PeerMetadata, ToggleMode, TrackManager, TrackMetadata, TrackMiddleware } from "../types";
 import { getRemoteOrLocalTrack } from "../utils/track";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { PeerStatus } from "../state.types";
+import type { ParticipantStatus } from "../state.types";
 
 interface TrackManagerConfig {
   mediaManager: MediaManager;
   tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
-  getCurrentPeerStatus: () => PeerStatus;
+  getCurrentPeerStatus: () => ParticipantStatus;
 }
 
 const TRACK_TYPE_TO_DEVICE = {

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -7,7 +7,7 @@ import type { ParticipantStatus } from "../state.types";
 interface TrackManagerConfig {
   mediaManager: MediaManager;
   tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
-  getCurrentPeerStatus: () => ParticipantStatus;
+  getCurrentParticipantStatus: () => ParticipantStatus;
 }
 
 const TRACK_TYPE_TO_DEVICE = {
@@ -15,7 +15,7 @@ const TRACK_TYPE_TO_DEVICE = {
   audio: "microphone",
 } as const;
 
-export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerStatus }: TrackManagerConfig): TrackManager => {
+export const useTrackManager = ({ mediaManager, tsClient, getCurrentParticipantStatus }: TrackManagerConfig): TrackManager => {
   const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
   const [paused, setPaused] = useState<boolean>(false);
   const clearMiddlewareFnRef = useRef<(() => void) | null>(null);
@@ -148,7 +148,7 @@ export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerStatus }
   }
 
   const stream = async () => {
-    if (getCurrentPeerStatus() !== "connected") return;
+    if (getCurrentParticipantStatus() !== "connected") return;
 
     if (currentTrack?.trackId) {
       await resumeStreaming();

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -148,7 +148,7 @@ export const useTrackManager = ({ mediaManager, tsClient, getCurrentPeerStatus }
   }
 
   const stream = async () => {
-    if (getCurrentPeerStatus() !== "joined") return;
+    if (getCurrentPeerStatus() !== "connected") return;
 
     if (currentTrack?.trackId) {
       await resumeStreaming();

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -15,7 +15,11 @@ const TRACK_TYPE_TO_DEVICE = {
   audio: "microphone",
 } as const;
 
-export const useTrackManager = ({ mediaManager, tsClient, getCurrentParticipantStatus }: TrackManagerConfig): TrackManager => {
+export const useTrackManager = ({
+  mediaManager,
+  tsClient,
+  getCurrentParticipantStatus,
+}: TrackManagerConfig): TrackManager => {
   const [currentTrackId, setCurrentTrackId] = useState<string | null>(null);
   const [paused, setPaused] = useState<boolean>(false);
   const clearMiddlewareFnRef = useRef<(() => void) | null>(null);

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -1,7 +1,7 @@
 export * from "./hooks/public";
 export * from "./fishjamProvider";
 
-export type { PeerState, Track, PeerId, TrackId, TrackWithOrigin, Origin, PeerStatus } from "./state.types";
+export type { PeerState, Track, PeerId, TrackId, TrackWithOrigin, Origin, ParticipantStatus } from "./state.types";
 
 export type {
   DeviceManagerConfig,

--- a/packages/react-client/src/state.types.ts
+++ b/packages/react-client/src/state.types.ts
@@ -36,4 +36,12 @@ export type PeerState = {
   tracks: Record<TrackId, Track>;
 };
 
-export type PeerStatus = "connecting" | "connected" | "error" | "idle";
+/**
+ * Represents the possible statuses of a peer connection.
+ *
+ * idle - Participant is not connected, either never connected or successfully disconnected.
+ * connecting - Participant is in the process of connecting.
+ * connected - Participant has successfully connected.
+ * error - There was an error in the connection process.
+ */
+export type ParticipantStatus = "connecting" | "connected" | "error" | "idle";

--- a/packages/react-client/src/state.types.ts
+++ b/packages/react-client/src/state.types.ts
@@ -36,4 +36,4 @@ export type PeerState = {
   tracks: Record<TrackId, Track>;
 };
 
-export type PeerStatus = "connecting" | "connected" | "authenticated" | "joined" | "error" | "closed" | null;
+export type PeerStatus = "connecting" | "connected" | "error" | "idle";


### PR DESCRIPTION
## Description

List of peers statuses has been shortened to: `connecting`, `connected`, `error`, `idle`.

Removed: `connected`, `authenticated`, `closed`, `null`;
Renamed: `joined` -> `connected`

## Motivation and Context

- The status `joined` was not descriptive.
- The user probably doesn't care about intermediate statuses (authenticated, web socket closed, web socket connected).

## Types of changes

Breaking change (fix or feature that would cause existing functionality to not work as expected)
