### PR TITLE
FCE-548 Make videroom compatible with Fishjam Chat

### DIFF
--- a/examples/react-client/fishjam-chat/src/App.tsx
+++ b/examples/react-client/fishjam-chat/src/App.tsx
@@ -45,7 +45,7 @@ function App() {
               <VideoTracks
                 key={id}
                 videoTracks={[...cameraTracks, ...screenshareVideoTracks]}
-                name={(metadata as { name?: string })?.name ?? id}
+                name={metadata?.displayName ?? id}
                 id={id}
               />
             ),

--- a/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomConnector.tsx
@@ -76,6 +76,7 @@ export function RoomConnector() {
     connect({
       token,
       url: fishjamUrl,
+      peerMetadata: { displayName: userName },
     });
   };
 


### PR DESCRIPTION
## Description

The FishjamChat now handles metadata correctly.

## Motivation and Context

FishjamChat showed `trackId` instead of `displayName` on the video tile and didn't send the local participant's name in the metadata.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
