### PR TITLE
FCE-554

### DIFF
--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -5,6 +5,7 @@ import { FishjamClient, type ReconnectConfig } from "@fishjam-cloud/ts-client";
 import { FishjamContext } from "./hooks/useFishjamContext";
 import { DeviceManager } from "./DeviceManager";
 import { usePeerStatus } from "./hooks/usePeerStatus";
+import { useFishjamClientState } from "./hooks/useFishjamClientState";
 
 interface FishjamProviderProps extends PropsWithChildren {
   config?: { reconnect?: ReconnectConfig | boolean };
@@ -33,6 +34,8 @@ export function FishjamProvider({ children, config, deviceManagerDefaultConfig }
     getCurrentPeerStatus,
   });
 
+  const clientState = useFishjamClientState(fishjamClientRef.current);
+
   const context = {
     fishjamClientRef,
     peerStatus,
@@ -42,6 +45,7 @@ export function FishjamProvider({ children, config, deviceManagerDefaultConfig }
     videoDeviceManagerRef,
     audioDeviceManagerRef,
     hasDevicesBeenInitializedRef,
+    clientState,
   };
 
   return <FishjamContext.Provider value={context}>{children}</FishjamContext.Provider>;

--- a/packages/react-client/src/hooks/internal.ts
+++ b/packages/react-client/src/hooks/internal.ts
@@ -1,1 +1,1 @@
-export { useFishjamClient_DO_NOT_USE } from "./useFishjamClient";
+export { useFishjamClient_DO_NOT_USE } from "./useFishjamClient_DO_NOT_USE";

--- a/packages/react-client/src/hooks/useConnection.ts
+++ b/packages/react-client/src/hooks/useConnection.ts
@@ -1,15 +1,18 @@
-import type { UseConnect } from "../types";
+import type { ConnectConfig, UseConnect } from "../types";
 import { useCallback } from "react";
-import { useFishjamClient_DO_NOT_USE } from "./useFishjamClient";
+import { useFishjamContext } from "./useFishjamContext";
 
 export function useConnect(): UseConnect {
-  const client = useFishjamClient_DO_NOT_USE();
+  const client = useFishjamContext().fishjamClientRef.current;
 
-  return useCallback((config) => client.connect(config), [client]);
+  return useCallback(
+    (config: ConnectConfig) => client.connect({ ...config, peerMetadata: config.peerMetadata ?? {} }),
+    [client],
+  );
 }
 
 export function useDisconnect() {
-  const client = useFishjamClient_DO_NOT_USE();
+  const client = useFishjamContext().fishjamClientRef.current;
 
   return useCallback(() => {
     client.disconnect();

--- a/packages/react-client/src/hooks/useFishjamClient_DO_NOT_USE.ts
+++ b/packages/react-client/src/hooks/useFishjamClient_DO_NOT_USE.ts
@@ -1,0 +1,8 @@
+import { useFishjamContext } from "./useFishjamContext";
+import { useMemo } from "react";
+
+export function useFishjamClient_DO_NOT_USE() {
+  const client = useFishjamContext().fishjamClientRef.current;
+
+  return useMemo(() => client, [client]);
+}

--- a/packages/react-client/src/hooks/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/useFishjamContext.ts
@@ -3,6 +3,7 @@ import { createContext, type MutableRefObject, useContext } from "react";
 import type { PeerMetadata, TrackMetadata, ScreenshareState, TrackManager } from "../types";
 import type { DeviceManager } from "../DeviceManager";
 import type { PeerStatus } from "../state.types";
+import type { FishjamClientState } from "./useFishjamClientState";
 
 export type FishjamContextType = {
   fishjamClientRef: MutableRefObject<FishjamClient<PeerMetadata, TrackMetadata>>;
@@ -13,6 +14,7 @@ export type FishjamContextType = {
   peerStatus: PeerStatus;
   videoTrackManager: TrackManager;
   audioTrackManager: TrackManager;
+  clientState: FishjamClientState;
 };
 
 export const FishjamContext = createContext<FishjamContextType | null>(null);

--- a/packages/react-client/src/hooks/useParticipants.ts
+++ b/packages/react-client/src/hooks/useParticipants.ts
@@ -1,6 +1,6 @@
 import type { PeerState } from "../state.types";
 import type { PeerStateWithTracks } from "../types";
-import { useFishjamClient_DO_NOT_USE } from "./useFishjamClient";
+import { useFishjamContext } from "./useFishjamContext";
 
 function getPeerWithDistinguishedTracks(peerState: PeerState): PeerStateWithTracks {
   const peerTracks = Object.values(peerState.tracks ?? {});
@@ -14,7 +14,8 @@ function getPeerWithDistinguishedTracks(peerState: PeerState): PeerStateWithTrac
 }
 
 export function useParticipants() {
-  const { peers, localPeer } = useFishjamClient_DO_NOT_USE();
+  const { clientState } = useFishjamContext();
+  const { localPeer, peers } = clientState;
 
   const localParticipant = localPeer ? getPeerWithDistinguishedTracks(localPeer) : null;
   const participants = Object.values(peers).map(getPeerWithDistinguishedTracks);


### PR DESCRIPTION
## Description

### The old `useFishjamClient_DO_NOT_USE`
- Methods from `useFishjamClient_DO_NOT_USE` like `connnect`, `addTrack` etc. were deleted because they weren't used.
- `useFishjamClient_DO_NOT_USE` was renamed to `useFishjamClientState` because it only holds state.
- There is no need to expose this state, so it isn't exported.
- There is only one invocation of this hook in `FishjamProvider` so there is only one active subscription. In the previous implementation, `useParticipants` creates a new subscription (`useSyncExternalStore`).

### The new `useFishjamClient_DO_NOT_USE`

To get access to methods and events from `ts-client` a new hook was introduced: `useFishjamClient_DO_NOT_USE`.

## Motivation and Context

`useFishjamClient_DO_NOT_USE` didn't exposed methods like `getStatistics()` and `events`

## Types of changes
Breaking change (fix or feature that would cause existing functionality to not work as expected)
