### PR TITLE
FCE-550 Visualise audio props

### DIFF
--- a/examples/react-client/fishjam-chat/src/App.tsx
+++ b/examples/react-client/fishjam-chat/src/App.tsx
@@ -35,30 +35,45 @@ function App() {
                 id="You"
                 name="You"
                 videoTrack={localParticipant.cameraTrack}
+                audioTrack={localParticipant.microphoneTrack}
               />
               {localParticipant.screenShareVideoTrack && (
                 <Tile
                   id="Your screen share"
                   name="Your screen share"
                   videoTrack={localParticipant.screenShareVideoTrack}
+                  audioTrack={localParticipant.screenShareAudioTrack}
                 />
               )}
             </>
           )}
 
           {participants.map(
-            ({ id, cameraTrack, screenShareVideoTrack, metadata }) => {
+            ({
+              id,
+              cameraTrack,
+              microphoneTrack,
+              screenShareVideoTrack,
+              screenShareAudioTrack,
+              metadata,
+            }) => {
               const label = metadata?.displayName ?? id;
 
               return (
                 <Fragment key={id}>
-                  <Tile id={id} name={label} videoTrack={cameraTrack} />
+                  <Tile
+                    id={id}
+                    name={label}
+                    videoTrack={cameraTrack}
+                    audioTrack={microphoneTrack}
+                  />
 
                   {screenShareVideoTrack && (
                     <Tile
                       id={id}
                       name={`Screen share: ${label}`}
                       videoTrack={screenShareVideoTrack}
+                      audioTrack={screenShareAudioTrack}
                     />
                   )}
                 </Fragment>

--- a/examples/react-client/fishjam-chat/src/components/Tile.tsx
+++ b/examples/react-client/fishjam-chat/src/components/Tile.tsx
@@ -5,12 +5,12 @@ import AudioVisualizer from "./AudioVisualizer.tsx";
 type Props = {
   id: string;
   name: string;
-  videoTrack: Track | undefined;
-  audioTrack?: Track | undefined;
+  videoTrack?: Track;
+  audioTrack?: Track;
 };
 
 export function Tile({ videoTrack, audioTrack, name, id }: Props) {
-  const isMuted = !audioTrack || audioTrack?.metadata?.paused;
+  const isMuted = !audioTrack || audioTrack.metadata?.paused;
   const isSpeaking = audioTrack?.vadStatus === "speech";
 
   return (

--- a/examples/react-client/fishjam-chat/src/components/Tile.tsx
+++ b/examples/react-client/fishjam-chat/src/components/Tile.tsx
@@ -1,30 +1,49 @@
 import VideoPlayer from "./VideoPlayer";
 import { Track } from "@fishjam-cloud/react-client";
+import AudioVisualizer from "./AudioVisualizer.tsx";
 
 type Props = {
   id: string;
   name: string;
   videoTrack: Track | undefined;
+  audioTrack?: Track | undefined;
 };
 
-export function Tile({ videoTrack, name, id }: Props) {
+export function Tile({ videoTrack, audioTrack, name, id }: Props) {
+  const isMuted = !audioTrack || audioTrack?.metadata?.paused;
+  const isSpeaking = audioTrack?.vadStatus === "speech";
+
   return (
     <div className="relative grid aspect-video place-content-center overflow-hidden rounded-md bg-zinc-300">
       {videoTrack && (
         <VideoPlayer
           className="z-20 rounded-md"
-          peerId={id}
           stream={videoTrack.stream}
+          peerId={id}
         />
       )}
 
       <div className="absolute bottom-2 left-0 z-30 grid w-full place-content-center text-center text-xs">
-        <span
+        <AudioVisualizer stream={audioTrack?.stream} />
+
+        <div
           title={videoTrack?.trackId}
-          className="rounded-sm bg-slate-100/60 px-1"
+          className="flex justify-between rounded-sm bg-slate-100/60 px-1"
         >
-          {name}
-        </span>
+          {isMuted ? (
+            <span title="Muted">🔇</span>
+          ) : (
+            <span title="Unmuted">🔊</span>
+          )}
+
+          <span>{name}</span>
+
+          {isSpeaking ? (
+            <span title="Speaking">🗣</span>
+          ) : (
+            <span title="Silent">🤐</span>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/examples/react-client/fishjam-chat/src/components/Tile.tsx
+++ b/examples/react-client/fishjam-chat/src/components/Tile.tsx
@@ -1,6 +1,6 @@
 import VideoPlayer from "./VideoPlayer";
 import { Track } from "@fishjam-cloud/react-client";
-import AudioVisualizer from "./AudioVisualizer.tsx";
+import AudioVisualizer from "./AudioVisualizer";
 
 type Props = {
   id: string;


### PR DESCRIPTION
## Description

![image](https://github.com/user-attachments/assets/ba86c4fe-b6c0-45aa-b726-08fa8dcde7ec)

Every tile on `fishjam-chat` displays:

- Audio waveform
- Muted indicator: 🔇 or 🔊
- Speaking indicator: 🗣 or 🤐

It is also possible to identify the audio origin (participant) and source (screen share vs. microphone).

## Motivation and Context

To be able to visualise audio streams.

## Types of changes

New feature (non-breaking change which adds functionality)
