### PR TITLE
FCE-650 Fix replace track promise

### DIFF
--- a/packages/ts-client/src/webrtc/webRTCEndpoint.ts
+++ b/packages/ts-client/src/webrtc/webRTCEndpoint.ts
@@ -429,7 +429,7 @@ export class WebRTCEndpoint<EndpointMetadata = any, TrackMetadata = any> extends
       stream.addTrack(track);
 
       this.commandsQueue.pushCommand({
-        handler: () => {
+        handler: async () => {
           this.localTrackManager.addTrackHandler(trackId, track, stream, parsedMetadata, simulcastConfig, maxBandwidth);
         },
         parse: () => this.localTrackManager.parseAddTrack(track, simulcastConfig, maxBandwidth),
@@ -500,11 +500,9 @@ export class WebRTCEndpoint<EndpointMetadata = any, TrackMetadata = any> extends
     const resolutionNotifier = new Deferred<void>();
 
     this.commandsQueue.pushCommand({
-      handler: () => {
-        this.localTrackManager.replaceTrackHandler(this, trackId, newTrack);
-      },
+      handler: () => this.localTrackManager.replaceTrackHandler(this, trackId, newTrack),
       resolutionNotifier,
-      resolve: 'immediately',
+      resolve: 'on-handler-resolve',
     });
 
     return resolutionNotifier.promise.then(() => {
@@ -574,7 +572,7 @@ export class WebRTCEndpoint<EndpointMetadata = any, TrackMetadata = any> extends
     const resolutionNotifier = new Deferred<void>();
 
     this.commandsQueue.pushCommand({
-      handler: () => {
+      handler: async () => {
         this.localTrackManager.removeTrackHandler(trackId);
       },
       resolutionNotifier,

--- a/packages/ts-client/src/webrtc/webRTCEndpoint.ts
+++ b/packages/ts-client/src/webrtc/webRTCEndpoint.ts
@@ -572,9 +572,7 @@ export class WebRTCEndpoint<EndpointMetadata = any, TrackMetadata = any> extends
     const resolutionNotifier = new Deferred<void>();
 
     this.commandsQueue.pushCommand({
-      handler: async () => {
-        this.localTrackManager.removeTrackHandler(trackId);
-      },
+      handler: async () => this.localTrackManager.removeTrackHandler(trackId),
       resolutionNotifier,
       resolve: 'after-renegotiation',
     });

--- a/packages/ts-client/src/webrtc/webRTCEndpoint.ts
+++ b/packages/ts-client/src/webrtc/webRTCEndpoint.ts
@@ -429,9 +429,8 @@ export class WebRTCEndpoint<EndpointMetadata = any, TrackMetadata = any> extends
       stream.addTrack(track);
 
       this.commandsQueue.pushCommand({
-        handler: async () => {
-          this.localTrackManager.addTrackHandler(trackId, track, stream, parsedMetadata, simulcastConfig, maxBandwidth);
-        },
+        handler: async () =>
+          this.localTrackManager.addTrackHandler(trackId, track, stream, parsedMetadata, simulcastConfig, maxBandwidth),
         parse: () => this.localTrackManager.parseAddTrack(track, simulcastConfig, maxBandwidth),
         resolve: 'after-renegotiation',
         resolutionNotifier,


### PR DESCRIPTION
## Description

The command handler waits for the `replaceTrack` promise to resolve.

## Motivation and Context

If there were two `replaceTrack` calls in a row, the second one would not resolve until a new command entered the `commandsQueue`.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
