### PR TITLE
FCE-652 Invalid state after mute/unmute track

### DIFF
--- a/packages/ts-client/src/webrtc/tracks/LocalTrack.ts
+++ b/packages/ts-client/src/webrtc/tracks/LocalTrack.ts
@@ -154,10 +154,8 @@ export class LocalTrack<EndpointMetadata, TrackMetadata> implements TrackCommon 
     this.trackContext.track = newTrack;
     this.mediaStreamTrackId = newTrack?.id ?? null;
 
-    if (action === 'mute') {
-      emitEvents('mute', webrtc, trackId);
-    } else if (action === 'unmute') {
-      emitEvents('unmute', webrtc, trackId);
+    if (action === 'mute' || action === 'unmute' ) {
+      emitEvents(action, webrtc, trackId);
     }
 
     try {

--- a/packages/ts-client/src/webrtc/tracks/muteTrackUtils.ts
+++ b/packages/ts-client/src/webrtc/tracks/muteTrackUtils.ts
@@ -1,7 +1,7 @@
 import type { WebRTCEndpoint } from '../webRTCEndpoint';
 import { generateMediaEvent } from '../mediaEvent';
 
-export function emitEvents<EndpointMetadata, TrackMetadata>(
+export function emitMutableEvents<EndpointMetadata, TrackMetadata>(
   action: 'mute' | 'unmute',
   webrtc: WebRTCEndpoint<EndpointMetadata, TrackMetadata>,
   trackId: string,

--- a/packages/ts-client/src/webrtc/tracks/muteUnmuteTrackUtils.ts
+++ b/packages/ts-client/src/webrtc/tracks/muteUnmuteTrackUtils.ts
@@ -1,0 +1,29 @@
+import type { WebRTCEndpoint } from '../webRTCEndpoint';
+import { generateMediaEvent } from '../mediaEvent';
+
+export function emitEvents<EndpointMetadata, TrackMetadata>(
+  action: 'mute' | 'unmute',
+  webrtc: WebRTCEndpoint<EndpointMetadata, TrackMetadata>,
+  trackId: string,
+) {
+  const mediaEventType = action === 'mute' ? `muteTrack` : `unmuteTrack`;
+  const localEventType = action === 'mute' ? `localTrackMuted` : `localTrackUnmuted`;
+
+  const mediaEvent = generateMediaEvent(mediaEventType, { trackId: trackId });
+  webrtc.sendMediaEvent(mediaEvent);
+
+  webrtc.emit(localEventType, { trackId: trackId });
+}
+
+export function getActionType(
+  currentTrack: MediaStreamTrack | null,
+  newTrack: MediaStreamTrack | null,
+): 'mute' | 'unmute' | 'replace' {
+  if (currentTrack && !newTrack) {
+    return 'mute';
+  } else if (!currentTrack && newTrack) {
+    return 'unmute';
+  } else {
+    return 'replace';
+  }
+}


### PR DESCRIPTION
## Description

Track in `trackContext` is assigned before emitting events. If `replaceTrack` fails, the opposite events will be emitted, and the state will be reverted.

## Motivation and Context

To fix the bug

## Types of changes

Bug fix (non-breaking change which fixes an issue)
