### PR TITLE
FCE-720 VAD hook

### DIFF
--- a/examples/react-client/fishjam-chat/src/App.tsx
+++ b/examples/react-client/fishjam-chat/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
           {localPeer && (
             <>
               <Tile
-                id="You"
+                id={localPeer.id}
                 name="You"
                 videoTrack={localPeer.cameraTrack}
                 audioTrack={localPeer.microphoneTrack}

--- a/examples/react-client/fishjam-chat/src/components/Tile.tsx
+++ b/examples/react-client/fishjam-chat/src/components/Tile.tsx
@@ -1,5 +1,5 @@
 import VideoPlayer from "./VideoPlayer";
-import { Track } from "@fishjam-cloud/react-client";
+import { Track, useVAD } from "@fishjam-cloud/react-client";
 import AudioVisualizer from "./AudioVisualizer";
 
 type Props = {
@@ -11,7 +11,8 @@ type Props = {
 
 export function Tile({ videoTrack, audioTrack, name, id }: Props) {
   const isMuted = !audioTrack || audioTrack.metadata?.paused;
-  const isSpeaking = audioTrack?.vadStatus === "speech";
+
+  const isSpeaking = useVAD([id])[id];
 
   return (
     <div className="relative grid aspect-video place-content-center overflow-hidden rounded-md bg-zinc-300">

--- a/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
+++ b/examples/react-client/use-camera-and-microphone/src/DeviceControls.tsx
@@ -1,21 +1,11 @@
-import type {
-  PeerStatus,
-  Device,
-  AudioDevice,
-} from "@fishjam-cloud/react-client";
+import type { PeerStatus, Device } from "@fishjam-cloud/react-client";
+import type { DeviceType } from "@fishjam-cloud/react-client/dist/DeviceManager";
 
 type DeviceControlsProps = {
   status: PeerStatus;
-} & (
-  | {
-      device: AudioDevice;
-      type: "audio";
-    }
-  | {
-      device: Device;
-      type: "video";
-    }
-);
+  device: Device;
+  type: DeviceType;
+};
 
 export const DeviceControls = ({
   device,

--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -1,4 +1,4 @@
-import type { AudioDevice } from "../../types/public";
+import type { Device } from "../../types/public";
 import { useDeviceManager } from "../deviceManagers/useDeviceManager";
 import { useFishjamContext } from "../useFishjamContext";
 
@@ -6,7 +6,7 @@ import { useFishjamContext } from "../useFishjamContext";
  *
  * @category Devices
  */
-export function useMicrophone(): AudioDevice {
+export function useMicrophone(): Device {
   const { audioTrackManager, audioDeviceManagerRef } = useFishjamContext();
   const { deviceState, status } = useDeviceManager(audioDeviceManagerRef.current);
 
@@ -19,7 +19,6 @@ export function useMicrophone(): AudioDevice {
   const trackId = currentTrack?.trackId ?? null;
   const devices = deviceState.devices ?? [];
   const activeDevice = deviceState.media?.deviceInfo ?? null;
-  const isAudioPlaying = currentTrack?.vadStatus === "speech";
   const isMuted = !deviceState.media?.enabled;
   const deviceError = deviceState.error ?? null;
   const isDeviceEnabled = Boolean(deviceState.media);
@@ -37,6 +36,5 @@ export function useMicrophone(): AudioDevice {
     activeDevice,
     isMuted,
     deviceError,
-    isAudioPlaying,
   };
 }

--- a/packages/react-client/src/hooks/public.ts
+++ b/packages/react-client/src/hooks/public.ts
@@ -6,3 +6,4 @@ export { useInitializeDevices } from "./devices/useInitializeDevices";
 export { usePeers } from "./usePeers";
 export { useScreenShare } from "./useScreenShare";
 export { useStatus } from "./useStatus";
+export { useVAD } from "./useVAD";

--- a/packages/react-client/src/hooks/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/useFishjamClientState.ts
@@ -1,7 +1,6 @@
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
-import type { Component, Endpoint, MessageEvents, Peer, TrackContext, FishjamClient } from "@fishjam-cloud/ts-client";
-import type { PeerMetadata, PeerState, TrackId, TrackMetadata } from "../types/internal";
-import type { Track } from "../types/public";
+import type { Component, Endpoint, MessageEvents, Peer, FishjamClient } from "@fishjam-cloud/ts-client";
+import type { PeerId, PeerMetadata, TrackMetadata } from "../types/internal";
 
 const eventNames = [
   "socketClose",
@@ -44,7 +43,7 @@ const eventNames = [
 ] as const satisfies (keyof MessageEvents<unknown, unknown>)[];
 
 export interface FishjamClientState {
-  peers: Record<string, Peer<PeerMetadata, TrackMetadata>>;
+  peers: Record<PeerId, Peer<PeerMetadata, TrackMetadata>>;
   components: Record<string, Component<PeerMetadata, TrackMetadata>>;
   localPeer: Endpoint<PeerMetadata, TrackMetadata> | null;
   isReconnecting: boolean;

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,4 +1,4 @@
-import { Component, Endpoint, Peer, TrackContext } from "@fishjam-cloud/ts-client";
+import type { Component, Endpoint, Peer, TrackContext } from "@fishjam-cloud/ts-client";
 import type { PeerMetadata, PeerState, TrackId, TrackMetadata } from "../types/internal";
 import type { PeerWithTracks, Track } from "../types/public";
 import { useFishjamContext } from "./useFishjamContext";

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,5 +1,6 @@
-import type { PeerState } from "../types/internal";
-import type { PeerWithTracks } from "../types/public";
+import { Component, Endpoint, Peer, TrackContext } from "@fishjam-cloud/ts-client";
+import type { PeerMetadata, PeerState, TrackId, TrackMetadata } from "../types/internal";
+import type { PeerWithTracks, Track } from "../types/public";
 import { useFishjamContext } from "./useFishjamContext";
 
 function getPeerWithDistinguishedTracks(peerState: PeerState): PeerWithTracks {
@@ -13,6 +14,35 @@ function getPeerWithDistinguishedTracks(peerState: PeerState): PeerWithTracks {
   return { ...peerState, cameraTrack, microphoneTrack, screenShareVideoTrack, screenShareAudioTrack };
 }
 
+function trackContextToTrack(track: TrackContext<PeerMetadata, TrackMetadata>): Track {
+  return {
+    metadata: track.metadata,
+    trackId: track.trackId,
+    stream: track.stream,
+    simulcastConfig: track.simulcastConfig ?? null,
+    encoding: track.encoding ?? null,
+    vadStatus: track.vadStatus,
+    track: track.track,
+  };
+}
+
+function endpointToPeerState(
+  peer:
+    | Peer<PeerMetadata, TrackMetadata>
+    | Component<PeerMetadata, TrackMetadata>
+    | Endpoint<PeerMetadata, TrackMetadata>,
+): PeerState {
+  const tracks = [...peer.tracks].reduce(
+    (acc, [, track]) => ({ ...acc, [track.trackId]: trackContextToTrack(track) }),
+    {} as Record<TrackId, Track>,
+  );
+  return {
+    metadata: peer.metadata,
+    id: peer.id,
+    tracks,
+  };
+}
+
 /**
  *
  * @category Connection
@@ -20,8 +50,13 @@ function getPeerWithDistinguishedTracks(peerState: PeerState): PeerWithTracks {
 export function usePeers() {
   const { clientState } = useFishjamContext();
 
-  const localPeer = clientState.localPeer ? getPeerWithDistinguishedTracks(clientState.localPeer) : null;
-  const peers = Object.values(clientState.peers).map(getPeerWithDistinguishedTracks);
+  const localPeer = clientState.localPeer
+    ? getPeerWithDistinguishedTracks(endpointToPeerState(clientState.localPeer))
+    : null;
+
+  const peers = Object.values(clientState.peers).map((peer) =>
+    getPeerWithDistinguishedTracks(endpointToPeerState(peer)),
+  );
 
   return { localPeer, peers };
 }

--- a/packages/react-client/src/hooks/useVAD.ts
+++ b/packages/react-client/src/hooks/useVAD.ts
@@ -1,0 +1,68 @@
+import { useEffect, useMemo, useState } from "react";
+import { PeerId, PeerMetadata, TrackId, TrackMetadata } from "../types/internal";
+import { useFishjamContext } from "./useFishjamContext";
+import { TrackContext, VadStatus } from "@fishjam-cloud/ts-client";
+import { useFishjamClientState } from "./useFishjamClientState";
+
+export const useVAD = (peerIds: PeerId[]): Record<PeerId, VadStatus> => {
+  const { fishjamClientRef } = useFishjamContext();
+  const { peers, localPeer } = useFishjamClientState(fishjamClientRef.current);
+
+  const microphoneTracksWithPeerIds = useMemo(
+    () =>
+      [localPeer, ...Object.values(peers)]
+        .filter((peer): peer is NonNullable<typeof peer> => Boolean(peer && peerIds.includes(peer.id)))
+        .map((peer) => ({
+          peerId: peer.id,
+          microphoneTracks: Array.from(peer.tracks.values()).filter((track) => track.metadata?.type === "microphone"),
+        })),
+    [localPeer, peers, peerIds],
+  );
+
+  const getDefaultVadStatuses = () =>
+    microphoneTracksWithPeerIds.reduce<Record<PeerId, Record<TrackId, VadStatus>>>(
+      (acc, peer) => ({
+        ...acc,
+        [peer.peerId]: peer.microphoneTracks.reduce((acc, track) => ({ ...acc, [track.trackId]: track.vadStatus }), {}),
+      }),
+      {},
+    );
+
+  const [_vadStatuses, setVadStatuses] = useState<Record<PeerId, Record<TrackId, VadStatus>>>(getDefaultVadStatuses);
+
+  useEffect(() => {
+    const unsubs = microphoneTracksWithPeerIds.map(({ peerId, microphoneTracks }) => {
+      const updateVadStatus = (track: TrackContext<PeerMetadata, TrackMetadata>) => {
+        setVadStatuses((prev) => ({
+          ...prev,
+          [peerId]: { ...prev[peerId], [track.trackId]: track.vadStatus },
+        }));
+      };
+
+      microphoneTracks.forEach((track) => {
+        track.on("voiceActivityChanged", updateVadStatus);
+      });
+
+      return () => {
+        microphoneTracks.forEach((track) => {
+          track.off("voiceActivityChanged", updateVadStatus);
+        });
+      };
+    });
+
+    return () => unsubs.forEach((unsub) => unsub());
+  }, [microphoneTracksWithPeerIds]);
+
+  const vadStatuses = useMemo(
+    () =>
+      Object.fromEntries(
+        Object.entries(_vadStatuses).map(([peerId, tracks]) => [
+          peerId,
+          Object.values(tracks).some((vad) => vad === "speech") ? "speech" : "silence",
+        ]),
+      ) satisfies Record<PeerId, VadStatus>,
+    [_vadStatuses],
+  );
+
+  return vadStatuses;
+};

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -8,6 +8,7 @@ export {
   usePeers,
   useScreenShare,
   useStatus,
+  useVAD,
 } from "./hooks/public";
 export { FishjamProvider } from "./fishjamProvider";
 
@@ -17,7 +18,6 @@ export {
   TracksMiddleware,
   PeerStatus,
   Device,
-  AudioDevice,
   PeerWithTracks,
   ConnectConfig,
   PersistLastDeviceHandlers,

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -56,8 +56,6 @@ export type Device = {
   isDeviceEnabled: boolean;
 } & Omit<TrackManager, "currentTrack">;
 
-export type AudioDevice = Device & { isAudioPlaying: boolean };
-
 export type PeerWithTracks = PeerState & DistinguishedTracks;
 
 export type ConnectConfig = Omit<TSClientConnectConfig<PeerMetadata>, "peerMetadata"> & { peerMetadata?: PeerMetadata };


### PR DESCRIPTION
## Description

Implements `useVAD` hook allowing users to listen to VAD updates of selected peers.
Introduces changes to the way `fishjamClientState` stores peers data.
The `TrackContext` is kept as it is in the `FIshjamClient` to allow access to the track events.
Transformations of the peers now happens in the `usePeers` hook, just before exposing the data outside.

## Motivation and Context

Users should have an opt-in way to listen to VAD updates.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
