### PR TITLE
FCE-730 Disable screen share after leaving the room

### DIFF
--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -76,7 +76,7 @@ export function FishjamProvider({
     autoStreamProps: autoStreamMicrophone,
   });
 
-  const screenShareManager = useScreenShareManager({ fishjamClient: fishjamClientRef.current });
+  const screenShareManager = useScreenShareManager({ fishjamClient: fishjamClientRef.current, getCurrentPeerStatus });
 
   const clientState = useFishjamClientState(fishjamClientRef.current);
 


### PR DESCRIPTION
## Description

The `stopStreaming` method checks if it is necessary to invoke `removeTrack`.

## Motivation and Context

Screen sharing didn't end automatically after leaving the room.

## Types of changes

Bug fix (non-breaking change which fixes an issue)
