### PR TITLE
FCE-658 `isStreaming` is false when track is paused

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DevicePicker.tsx
@@ -54,7 +54,7 @@ const DeviceSelect: FC<DeviceSelectProps> = ({ device, label }) => {
           </Button>
         ) : (
           <Button
-            disabled={!hasJoinedRoom}
+            disabled={!hasJoinedRoom || !device.stream}
             onClick={async () => {
               await device.startStreaming();
             }}

--- a/packages/react-client/src/hooks/devices/useCamera.ts
+++ b/packages/react-client/src/hooks/devices/useCamera.ts
@@ -14,7 +14,7 @@ export function useCamera(): Device {
 
   const stream = deviceState.media?.stream ?? null;
   const currentMiddleware = deviceState.currentMiddleware ?? null;
-  const isStreaming = Boolean(currentTrack?.stream);
+  const isStreaming = Boolean(currentTrack?.stream && !trackManager.paused);
   const track = stream?.getAudioTracks()[0] ?? null;
   const trackId = currentTrack?.trackId ?? null;
   const devices = deviceState.devices ?? [];

--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -14,7 +14,7 @@ export function useMicrophone(): AudioDevice {
 
   const stream = deviceState.media?.stream ?? null;
   const currentMiddleware = deviceState.currentMiddleware ?? null;
-  const isStreaming = Boolean(currentTrack?.stream);
+  const isStreaming = Boolean(currentTrack?.stream && !trackManager.paused);
   const track = stream?.getAudioTracks()[0] ?? null;
   const trackId = currentTrack?.trackId ?? null;
   const devices = deviceState.devices ?? [];


### PR DESCRIPTION
## Description

`isStreaming` is set to false when the track is paused.

## Motivation and Context

When the track was paused, `isStreaming` was false.

## Types of changes

Bug fix (non-breaking change which fixes an issue)