### PR TITLE
Remove peer/server structure

### DIFF
--- a/packages/ts-client/src/webrtc/tracks/Remote.ts
+++ b/packages/ts-client/src/webrtc/tracks/Remote.ts
@@ -132,7 +132,7 @@ export class Remote<EndpointMetadata, TrackMetadata> {
     if (!endpoint) throw new Error(`Endpoint ${data.id} not found`);
 
     // mutation in place
-    this.updateEndpointMetadata(endpoint, data.metadata.peer);
+    this.updateEndpointMetadata(endpoint, data.metadata);
 
     this.emit('endpointUpdated', endpoint);
   };
@@ -142,13 +142,13 @@ export class Remote<EndpointMetadata, TrackMetadata> {
     metadata: unknown,
   ) => {
     try {
-      endpoint.metadata.peer = this.endpointMetadataParser(metadata);
+      endpoint.metadata = this.endpointMetadataParser(metadata);
       endpoint.metadataParsingError = undefined;
     } catch (error) {
-      endpoint.metadata.peer = undefined;
+      endpoint.metadata = undefined;
       endpoint.metadataParsingError = error;
     }
-    endpoint.rawMetadata.peer = metadata;
+    endpoint.rawMetadata = metadata;
   };
 
   public removeRemoteEndpoint = (endpointId: EndpointId) => {

--- a/packages/ts-client/src/webrtc/types.ts
+++ b/packages/ts-client/src/webrtc/types.ts
@@ -321,14 +321,8 @@ export interface Endpoint<EndpointMetadata, TrackMetadata> {
   /**
    * Any information that was provided in {@link WebRTCEndpoint.connect}.
    */
-  metadata: {
-    peer?: EndpointMetadata;
-    server: any;
-  };
-  rawMetadata: {
-    peer?: any;
-    server: any;
-  };
+  metadata: any;
+  rawMetadata: any;
   metadataParsingError?: any;
   /**
    * List of tracks that are sent by the endpoint.


### PR DESCRIPTION
## Description

Remove the requirement for the endpoint (peer) metadata is added by Fishjam. Therefore, if we add such type definitions they should be in the `FishjamClient`, not `WebRTCEndpoint`.

Why? So far the `WebRTCEndpoint` has been used as an SDK for Membrane RTC Engine. If we add such changes, this effectively means that we no longer support SDK's for the RTC Engine.

## Motivation and Context

Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
