### PR TITLE
FCE-856/allow user to set metadata type on `usePeers`

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/RoomView.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomView.tsx
@@ -5,7 +5,7 @@ import { CallToolbar } from "./CallToolbar";
 import { nonNullablePredicate } from "@/lib/utils";
 
 export const RoomView = () => {
-  const { localPeer, remotePeers } = usePeers();
+  const { localPeer, remotePeers } = usePeers<{ displayName: string }>();
 
   const trackAmount = [localPeer, ...remotePeers]
     .filter(nonNullablePredicate)
@@ -76,7 +76,7 @@ export const RoomView = () => {
                   )}
                 </Fragment>
               );
-            },
+            }
           )}
         </div>
       </section>

--- a/examples/react-client/fishjam-chat/src/components/RoomView.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomView.tsx
@@ -76,7 +76,7 @@ export const RoomView = () => {
                   )}
                 </Fragment>
               );
-            }
+            },
           )}
         </div>
       </section>

--- a/examples/ts-client/minimal/src/main.ts
+++ b/examples/ts-client/minimal/src/main.ts
@@ -16,12 +16,8 @@ type PeerMetadata = {
   name: string;
 };
 
-type TrackMetadata = {
-  type: "camera" | "screen";
-};
-
 // Creates a new FishjamClient object to interact with Fishjam
-const client = new FishjamClient<PeerMetadata, TrackMetadata>();
+const client = new FishjamClient<PeerMetadata>();
 
 const peerToken = prompt("Enter peer token") ?? "YOUR_PEER_TOKEN";
 
@@ -80,5 +76,7 @@ async function startScreenSharing() {
   // Add local MediaStream to the client
   screenStream
     .getTracks()
-    .forEach((track) => client.addTrack(track, { type: "screen" }));
+    .forEach((track) =>
+      client.addTrack(track, { type: "screenShareVideo", paused: false }),
+    );
 }

--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -1,6 +1,5 @@
 import { useRef, type PropsWithChildren } from "react";
 import { useTrackManager } from "./hooks/useTrackManager";
-import type { PeerMetadata } from "./types/internal";
 import { FishjamClient, type ReconnectConfig } from "@fishjam-cloud/ts-client";
 import type { FishjamContextType } from "./hooks/useFishjamContext";
 import { FishjamContext } from "./hooks/useFishjamContext";
@@ -33,7 +32,7 @@ export function FishjamProvider({
   autoStreamCamera,
   autoStreamMicrophone,
 }: FishjamProviderProps) {
-  const fishjamClientRef = useRef(new FishjamClient<PeerMetadata>({ reconnect }));
+  const fishjamClientRef = useRef(new FishjamClient({ reconnect }));
 
   const hasDevicesBeenInitializedRef = useRef(false);
   const storage = persistLastDevice;

--- a/packages/react-client/src/fishjamProvider.tsx
+++ b/packages/react-client/src/fishjamProvider.tsx
@@ -1,6 +1,6 @@
 import { useRef, type PropsWithChildren } from "react";
 import { useTrackManager } from "./hooks/useTrackManager";
-import type { PeerMetadata, TrackMetadata } from "./types/internal";
+import type { PeerMetadata } from "./types/internal";
 import { FishjamClient, type ReconnectConfig } from "@fishjam-cloud/ts-client";
 import type { FishjamContextType } from "./hooks/useFishjamContext";
 import { FishjamContext } from "./hooks/useFishjamContext";
@@ -33,7 +33,7 @@ export function FishjamProvider({
   autoStreamCamera,
   autoStreamMicrophone,
 }: FishjamProviderProps) {
-  const fishjamClientRef = useRef(new FishjamClient<PeerMetadata, TrackMetadata>({ reconnect }));
+  const fishjamClientRef = useRef(new FishjamClient<PeerMetadata>({ reconnect }));
 
   const hasDevicesBeenInitializedRef = useRef(false);
   const storage = persistLastDevice;

--- a/packages/react-client/src/hooks/useConnection.ts
+++ b/packages/react-client/src/hooks/useConnection.ts
@@ -5,8 +5,10 @@ import type { ConnectConfig } from "../types/public";
 /**
  *
  * @category Connection
+ *
+ * @typeParam P Type of metadata set by peer while connecting to a room.
  */
-export function useConnect(): (config: ConnectConfig) => Promise<void> {
+export function useConnect(): <P>(config: ConnectConfig<P>) => Promise<void> {
   const client = useFishjamContext().fishjamClientRef.current;
 
   return useCallback((config) => client.connect({ ...config, peerMetadata: config.peerMetadata ?? {} }), [client]);

--- a/packages/react-client/src/hooks/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/useFishjamClientState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
-import type { Component, MessageEvents, Peer, FishjamClient } from "@fishjam-cloud/ts-client";
-import type { PeerId, PeerMetadata } from "../types/internal";
+import type { Component, MessageEvents, Peer, FishjamClient, MetadataDefault } from "@fishjam-cloud/ts-client";
+import type { PeerId } from "../types/internal";
 
 const eventNames = [
   "socketClose",
@@ -40,12 +40,12 @@ const eventNames = [
   "localPeerMetadataChanged",
   "localTrackMetadataChanged",
   "disconnectRequested",
-] as const satisfies (keyof MessageEvents<unknown>)[];
+] as const satisfies (keyof MessageEvents<unknown, unknown>)[];
 
-export interface FishjamClientState {
-  peers: Record<PeerId, Peer<PeerMetadata>>;
+export interface FishjamClientState<P = MetadataDefault, S = MetadataDefault> {
+  peers: Record<PeerId, Peer<P, S>>;
   components: Record<string, Component>;
-  localPeer: Peer<PeerMetadata> | null;
+  localPeer: Peer<P, S> | null;
   isReconnecting: boolean;
 }
 
@@ -53,7 +53,7 @@ export interface FishjamClientState {
 This is an internally used hook.
 It is not meant to be used by the end user.
 */
-export function useFishjamClientState(fishjamClient: FishjamClient<PeerMetadata>): FishjamClientState {
+export function useFishjamClientState<P, S>(fishjamClient: FishjamClient<P, S>): FishjamClientState<P, S> {
   const client = useMemo(() => fishjamClient, [fishjamClient]);
   const mutationRef = useRef(false);
 
@@ -71,9 +71,9 @@ export function useFishjamClientState(fishjamClient: FishjamClient<PeerMetadata>
     [client],
   );
 
-  const lastSnapshotRef = useRef<FishjamClientState | null>(null);
+  const lastSnapshotRef = useRef<FishjamClientState<P, S> | null>(null);
 
-  const getSnapshot: () => FishjamClientState = useCallback(() => {
+  const getSnapshot: () => FishjamClientState<P, S> = useCallback(() => {
     if (mutationRef.current || lastSnapshotRef.current === null) {
       const peers = client.getRemotePeers();
       const components = client.getRemoteComponents();

--- a/packages/react-client/src/hooks/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/useFishjamClientState.ts
@@ -1,5 +1,5 @@
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
-import type { Component, MessageEvents, Peer, FishjamClient, MetadataDefault } from "@fishjam-cloud/ts-client";
+import type { Component, MessageEvents, Peer, FishjamClient, GenericMetadata } from "@fishjam-cloud/ts-client";
 import type { PeerId } from "../types/internal";
 
 const eventNames = [
@@ -42,7 +42,7 @@ const eventNames = [
   "disconnectRequested",
 ] as const satisfies (keyof MessageEvents<unknown, unknown>)[];
 
-export interface FishjamClientState<P = MetadataDefault, S = MetadataDefault> {
+export interface FishjamClientState<P = GenericMetadata, S = GenericMetadata> {
   peers: Record<PeerId, Peer<P, S>>;
   components: Record<string, Component>;
   localPeer: Peer<P, S> | null;

--- a/packages/react-client/src/hooks/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/useFishjamClientState.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 import type { Component, MessageEvents, Peer, FishjamClient } from "@fishjam-cloud/ts-client";
-import type { PeerId, PeerMetadata, TrackMetadata } from "../types/internal";
+import type { PeerId, PeerMetadata } from "../types/internal";
 
 const eventNames = [
   "socketClose",
@@ -40,12 +40,12 @@ const eventNames = [
   "localPeerMetadataChanged",
   "localTrackMetadataChanged",
   "disconnectRequested",
-] as const satisfies (keyof MessageEvents<unknown, unknown>)[];
+] as const satisfies (keyof MessageEvents<unknown>)[];
 
 export interface FishjamClientState {
-  peers: Record<PeerId, Peer<PeerMetadata, TrackMetadata>>;
+  peers: Record<PeerId, Peer<PeerMetadata>>;
   components: Record<string, Component>;
-  localPeer: Peer<PeerMetadata, TrackMetadata> | null;
+  localPeer: Peer<PeerMetadata> | null;
   isReconnecting: boolean;
 }
 
@@ -53,7 +53,7 @@ export interface FishjamClientState {
 This is an internally used hook.
 It is not meant to be used by the end user.
 */
-export function useFishjamClientState(fishjamClient: FishjamClient<PeerMetadata, TrackMetadata>): FishjamClientState {
+export function useFishjamClientState(fishjamClient: FishjamClient<PeerMetadata>): FishjamClientState {
   const client = useMemo(() => fishjamClient, [fishjamClient]);
   const mutationRef = useRef(false);
 

--- a/packages/react-client/src/hooks/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/useFishjamContext.ts
@@ -1,12 +1,12 @@
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import { createContext, type MutableRefObject, useContext } from "react";
-import type { PeerMetadata, TrackMetadata, TrackManager } from "../types/internal";
+import type { PeerMetadata, TrackManager } from "../types/internal";
 import type { DeviceManager } from "../DeviceManager";
 import type { FishjamClientState } from "./useFishjamClientState";
 import type { BandwidthLimits, PeerStatus, ScreenshareApi } from "../types/public";
 
 export type FishjamContextType = {
-  fishjamClientRef: MutableRefObject<FishjamClient<PeerMetadata, TrackMetadata>>;
+  fishjamClientRef: MutableRefObject<FishjamClient<PeerMetadata>>;
   videoDeviceManagerRef: MutableRefObject<DeviceManager>;
   audioDeviceManagerRef: MutableRefObject<DeviceManager>;
   hasDevicesBeenInitializedRef: MutableRefObject<boolean>;

--- a/packages/react-client/src/hooks/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/useFishjamContext.ts
@@ -1,12 +1,12 @@
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import { createContext, type MutableRefObject, useContext } from "react";
-import type { PeerMetadata, TrackManager } from "../types/internal";
+import type { TrackManager } from "../types/internal";
 import type { DeviceManager } from "../DeviceManager";
 import type { FishjamClientState } from "./useFishjamClientState";
 import type { BandwidthLimits, PeerStatus, ScreenshareApi } from "../types/public";
 
 export type FishjamContextType = {
-  fishjamClientRef: MutableRefObject<FishjamClient<PeerMetadata>>;
+  fishjamClientRef: MutableRefObject<FishjamClient>;
   videoDeviceManagerRef: MutableRefObject<DeviceManager>;
   audioDeviceManagerRef: MutableRefObject<DeviceManager>;
   hasDevicesBeenInitializedRef: MutableRefObject<boolean>;

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
-import type { PeerMetadata } from "../types/internal";
 import type { PeerStatus } from "../types/public";
 
-export const usePeerStatus = (client: FishjamClient<PeerMetadata>) => {
+export const usePeerStatus = (client: FishjamClient) => {
   const [peerStatus, setPeerStatusState] = useState<PeerStatus>("idle");
   const peerStatusRef = useRef<PeerStatus>("idle");
 

--- a/packages/react-client/src/hooks/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/usePeerStatus.ts
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
-import type { PeerMetadata, TrackMetadata } from "../types/internal";
+import type { PeerMetadata } from "../types/internal";
 import type { PeerStatus } from "../types/public";
 
-export const usePeerStatus = (client: FishjamClient<PeerMetadata, TrackMetadata>) => {
+export const usePeerStatus = (client: FishjamClient<PeerMetadata>) => {
   const [peerStatus, setPeerStatusState] = useState<PeerStatus>("idle");
   const peerStatusRef = useRef<PeerStatus>("idle");
 

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -22,8 +22,7 @@ function trackContextToTrack(track: FishjamTrackContext | TrackContext): Track {
 }
 
 function getPeerWithDistinguishedTracks<P, S>(peer: Peer<P, S> | Component | Endpoint): PeerWithTracks<P, S> {
-  const trackList: (FishjamTrackContext | TrackContext)[] = Object.values(peer.tracks ?? {});
-  const tracks = trackList.map((track) => trackContextToTrack(track));
+  const tracks = [...peer.tracks.values()].map(trackContextToTrack);
 
   const cameraTrack = tracks.find(({ metadata }) => metadata?.type === "camera");
   const microphoneTrack = tracks.find(({ metadata }) => metadata?.type === "microphone");

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -66,6 +66,9 @@ export type UsePeersResult<P, S> = {
 /**
  *
  * @category Connection
+ *
+ * @typeParam P Type of metadata set by peer while connecting to a room.
+ * @typeParam S Type of metadata set by the server while creating a peer.
  */
 export function usePeers<P = Record<string, unknown>, S = Record<string, unknown>>(): UsePeersResult<P, S> {
   const { clientState } = useFishjamContext();

--- a/packages/react-client/src/hooks/useScreenShare.ts
+++ b/packages/react-client/src/hooks/useScreenShare.ts
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import { getRemoteOrLocalTrack } from "../utils/track";
 import type { TracksMiddleware, ScreenshareApi, PeerStatus } from "../types/public";
-import type { PeerMetadata, ScreenShareState } from "../types/internal";
+import type { ScreenShareState } from "../types/internal";
 import { useFishjamContext } from "./useFishjamContext";
 
 interface ScreenShareManagerProps {
-  fishjamClient: FishjamClient<PeerMetadata>;
+  fishjamClient: FishjamClient;
   getCurrentPeerStatus: () => PeerStatus;
 }
 

--- a/packages/react-client/src/hooks/useScreenShare.ts
+++ b/packages/react-client/src/hooks/useScreenShare.ts
@@ -25,7 +25,10 @@ export const useScreenShareManager = ({
   const stream = state.stream ?? null;
   const [videoTrack, audioTrack] = stream ? getTracksFromStream(stream) : [null, null];
 
-  const getDisplayName = () => fishjamClient.getLocalPeer()?.metadata?.peer?.displayName;
+  const getDisplayName = () => {
+    const name = fishjamClient.getLocalPeer()?.metadata?.peer?.displayName;
+    if (typeof name === "string") return name;
+  };
 
   const startStreaming: ScreenshareApi["startStreaming"] = async (props) => {
     const stream = await navigator.mediaDevices.getDisplayMedia({

--- a/packages/react-client/src/hooks/useScreenShare.ts
+++ b/packages/react-client/src/hooks/useScreenShare.ts
@@ -2,11 +2,11 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
 import { getRemoteOrLocalTrack } from "../utils/track";
 import type { TracksMiddleware, ScreenshareApi, PeerStatus } from "../types/public";
-import type { PeerMetadata, ScreenShareState, TrackMetadata } from "../types/internal";
+import type { PeerMetadata, ScreenShareState } from "../types/internal";
 import { useFishjamContext } from "./useFishjamContext";
 
 interface ScreenShareManagerProps {
-  fishjamClient: FishjamClient<PeerMetadata, TrackMetadata>;
+  fishjamClient: FishjamClient<PeerMetadata>;
   getCurrentPeerStatus: () => PeerStatus;
 }
 

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -1,12 +1,12 @@
-import type { FishjamClient } from "@fishjam-cloud/ts-client";
-import type { MediaManager, PeerMetadata, TrackManager, TrackMetadata } from "../types/internal";
+import type { FishjamClient, TrackMetadata } from "@fishjam-cloud/ts-client";
+import type { MediaManager, PeerMetadata, TrackManager } from "../types/internal";
 import { getConfigAndBandwidthFromProps, getRemoteOrLocalTrack } from "../utils/track";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { BandwidthLimits, PeerStatus, StartStreamingProps, TrackMiddleware } from "../types/public";
 
 interface TrackManagerConfig {
   mediaManager: MediaManager;
-  tsClient: FishjamClient<PeerMetadata, TrackMetadata>;
+  tsClient: FishjamClient<PeerMetadata>;
   getCurrentPeerStatus: () => PeerStatus;
   bandwidthLimits: BandwidthLimits;
   autoStreamProps?: StartStreamingProps | false;

--- a/packages/react-client/src/hooks/useTrackManager.ts
+++ b/packages/react-client/src/hooks/useTrackManager.ts
@@ -1,12 +1,12 @@
 import type { FishjamClient, TrackMetadata } from "@fishjam-cloud/ts-client";
-import type { MediaManager, PeerMetadata, TrackManager } from "../types/internal";
+import type { MediaManager, TrackManager } from "../types/internal";
 import { getConfigAndBandwidthFromProps, getRemoteOrLocalTrack } from "../utils/track";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { BandwidthLimits, PeerStatus, StartStreamingProps, TrackMiddleware } from "../types/public";
 
 interface TrackManagerConfig {
   mediaManager: MediaManager;
-  tsClient: FishjamClient<PeerMetadata>;
+  tsClient: FishjamClient;
   getCurrentPeerStatus: () => PeerStatus;
   bandwidthLimits: BandwidthLimits;
   autoStreamProps?: StartStreamingProps | false;
@@ -63,10 +63,14 @@ export const useTrackManager = ({
       // see `getRemoteOrLocalTrackContext()` explanation
       setCurrentTrackId(media.track.id);
 
+      const deviceType = getDeviceType(mediaManager);
+      const trackMetadata: TrackMetadata = { type: deviceType, paused: false };
+
       const displayName = tsClient.getLocalPeer()?.metadata?.peer?.displayName;
 
-      const deviceType = getDeviceType(mediaManager);
-      const trackMetadata: TrackMetadata = { type: deviceType, displayName, paused: false };
+      if (typeof displayName === "string") {
+        trackMetadata.displayName = displayName;
+      }
 
       const [maxBandwidth, simulcastConfig] = getConfigAndBandwidthFromProps(props.simulcast, bandwidthLimits);
 

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -11,10 +11,6 @@ export type PeerState<P, S> = {
   tracks: Track[];
 };
 
-export type PeerMetadata = {
-  displayName?: string;
-};
-
 export type DevicesStatus = "OK" | "Error" | "Not requested" | "Requesting";
 export type MediaStatus = "OK" | "Error" | "Not requested" | "Requesting";
 

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -5,10 +5,10 @@ import type { Peer } from "@fishjam-cloud/ts-client";
 export type TrackId = string;
 export type PeerId = string;
 
-export type PeerState = {
+export type PeerState<P, S> = {
   id: PeerId;
-  metadata?: Peer["metadata"];
-  tracks: Record<TrackId, Track>;
+  metadata?: Peer<P, S>["metadata"];
+  tracks: Track[];
 };
 
 export type PeerMetadata = {

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -7,18 +7,11 @@ export type PeerId = string;
 
 export type PeerState = {
   id: PeerId;
-  metadata?: Peer<PeerMetadata, TrackMetadata>["metadata"];
+  metadata?: Peer["metadata"];
   tracks: Record<TrackId, Track>;
 };
 
 export type PeerMetadata = {
-  displayName?: string;
-};
-
-export type TrackMetadata = {
-  type: "camera" | "microphone" | "screenShareVideo" | "screenShareAudio";
-  paused: boolean;
-  // track label used in recordings
   displayName?: string;
 };
 

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -5,11 +5,11 @@ import type {
   ConnectConfig as TSClientConnectConfig,
   VadStatus,
 } from "@fishjam-cloud/ts-client";
+
 import type {
   DeviceError,
   DeviceManagerStatus,
   DistinguishedTracks,
-  PeerMetadata,
   PeerState,
   TrackId,
   TrackManager,
@@ -58,7 +58,7 @@ export type Device = {
 
 export type PeerWithTracks<P, S> = PeerState<P, S> & DistinguishedTracks;
 
-export type ConnectConfig = Omit<TSClientConnectConfig<PeerMetadata>, "peerMetadata"> & { peerMetadata?: PeerMetadata };
+export type ConnectConfig<P> = Omit<TSClientConnectConfig<P>, "peerMetadata"> & { peerMetadata?: P };
 
 export type PersistLastDeviceHandlers = {
   getLastDevice: () => MediaDeviceInfo | null;

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -1,6 +1,7 @@
 import type {
   Encoding,
   SimulcastConfig,
+  TrackMetadata,
   ConnectConfig as TSClientConnectConfig,
   VadStatus,
 } from "@fishjam-cloud/ts-client";
@@ -12,7 +13,6 @@ import type {
   PeerState,
   TrackId,
   TrackManager,
-  TrackMetadata,
 } from "./internal";
 
 export type Track = {
@@ -56,7 +56,7 @@ export type Device = {
   isDeviceEnabled: boolean;
 } & Omit<TrackManager, "currentTrack">;
 
-export type PeerWithTracks = PeerState & DistinguishedTracks;
+export type PeerWithTracks<P, S> = PeerState<P, S> & DistinguishedTracks;
 
 export type ConnectConfig = Omit<TSClientConnectConfig<PeerMetadata>, "peerMetadata"> & { peerMetadata?: PeerMetadata };
 

--- a/packages/react-client/src/utils/track.ts
+++ b/packages/react-client/src/utils/track.ts
@@ -1,5 +1,5 @@
-import type { Encoding, FishjamClient, TrackContext } from "@fishjam-cloud/ts-client";
-import type { PeerMetadata, TrackMetadata } from "../types/internal";
+import type { Encoding, FishjamClient, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
+import type { PeerMetadata } from "../types/internal";
 import type { BandwidthLimits, Track } from "../types/public";
 
 // In most cases, the track is identified by its remote track ID.
@@ -11,7 +11,7 @@ import type { BandwidthLimits, Track } from "../types/public";
 // However, in that event handler, we don't yet have the remote track ID.
 // Therefore, for that brief moment, we will use the local track ID from the MediaStreamTrack object to identify the track.
 const getRemoteOrLocalTrackContext = <PeerMetadata, TrackMetadata>(
-  tsClient: FishjamClient<PeerMetadata, TrackMetadata>,
+  tsClient: FishjamClient<PeerMetadata>,
   remoteOrLocalTrackId: string | null,
 ): TrackContext | null => {
   if (!remoteOrLocalTrackId) return null;
@@ -36,10 +36,7 @@ const getTrackFromContext = (context: TrackContext): Track => ({
   track: context.track,
 });
 
-export const getRemoteOrLocalTrack = (
-  tsClient: FishjamClient<PeerMetadata, TrackMetadata>,
-  remoteOrLocalTrackId: string | null,
-) => {
+export const getRemoteOrLocalTrack = (tsClient: FishjamClient<PeerMetadata>, remoteOrLocalTrackId: string | null) => {
   const context = getRemoteOrLocalTrackContext(tsClient, remoteOrLocalTrackId);
   if (!context) return null;
   return getTrackFromContext(context);

--- a/packages/react-client/src/utils/track.ts
+++ b/packages/react-client/src/utils/track.ts
@@ -1,5 +1,4 @@
 import type { Encoding, FishjamClient, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
-import type { PeerMetadata } from "../types/internal";
 import type { BandwidthLimits, Track } from "../types/public";
 
 // In most cases, the track is identified by its remote track ID.
@@ -36,7 +35,7 @@ const getTrackFromContext = (context: TrackContext): Track => ({
   track: context.track,
 });
 
-export const getRemoteOrLocalTrack = (tsClient: FishjamClient<PeerMetadata>, remoteOrLocalTrackId: string | null) => {
+export const getRemoteOrLocalTrack = (tsClient: FishjamClient, remoteOrLocalTrackId: string | null) => {
   const context = getRemoteOrLocalTrackContext(tsClient, remoteOrLocalTrackId);
   if (!context) return null;
   return getTrackFromContext(context);

--- a/packages/react-client/src/utils/track.ts
+++ b/packages/react-client/src/utils/track.ts
@@ -10,7 +10,7 @@ import type { BandwidthLimits, Track } from "../types/public";
 // This event will refresh the internal state of this object.
 // However, in that event handler, we don't yet have the remote track ID.
 // Therefore, for that brief moment, we will use the local track ID from the MediaStreamTrack object to identify the track.
-const getRemoteOrLocalTrackContext = <PeerMetadata, TrackMetadata>(
+const getRemoteOrLocalTrackContext = <PeerMetadata>(
   tsClient: FishjamClient<PeerMetadata>,
   remoteOrLocalTrackId: string | null,
 ): TrackContext | null => {

--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -223,7 +223,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
   /**
    * Returns a snapshot of currently received remote peers.
    */
-  public getRemotePeers(): Record<string, Peer<PeerMetadata>> {
+  public getRemotePeers(): Record<string, Peer<PeerMetadata, ServerMetadata>> {
     return Object.entries(this.webrtc?.getRemoteEndpoints() ?? {}).reduce(
       (acc, [id, peer]) => (isPeer(peer) ? { ...acc, [id]: peer } : acc),
       {},
@@ -237,8 +237,8 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     );
   }
 
-  public getLocalPeer(): Peer<PeerMetadata> | null {
-    return (this.webrtc?.getLocalEndpoint() as Peer<PeerMetadata>) || null;
+  public getLocalPeer(): Peer<PeerMetadata, ServerMetadata> | null {
+    return (this.webrtc?.getLocalEndpoint() as Peer<PeerMetadata, ServerMetadata>) || null;
   }
 
   public getBandwidthEstimation(): bigint {

--- a/packages/ts-client/src/connectEventsHandler.ts
+++ b/packages/ts-client/src/connectEventsHandler.ts
@@ -1,6 +1,6 @@
 import type { FishjamClient } from './FishjamClient';
 
-export function connectEventsHandler<P, T>(fishjamClient: FishjamClient<P, T>) {
+export function connectEventsHandler<P>(fishjamClient: FishjamClient<P>) {
   return new Promise<void>((resolve, reject) => {
     const onSuccess = () => {
       clearCallbacks();

--- a/packages/ts-client/src/connectEventsHandler.ts
+++ b/packages/ts-client/src/connectEventsHandler.ts
@@ -1,6 +1,6 @@
 import type { FishjamClient } from './FishjamClient';
 
-export function connectEventsHandler<P>(fishjamClient: FishjamClient<P>) {
+export function connectEventsHandler<P, S>(fishjamClient: FishjamClient<P, S>) {
   return new Promise<void>((resolve, reject) => {
     const onSuccess = () => {
       clearCallbacks();

--- a/packages/ts-client/src/index.ts
+++ b/packages/ts-client/src/index.ts
@@ -7,7 +7,7 @@ export type {
   FishjamTrackContext,
   TrackMetadata,
   Metadata,
-  MetadataDefault,
+  GenericMetadata,
 } from './types';
 
 export { FishjamClient } from './FishjamClient';

--- a/packages/ts-client/src/index.ts
+++ b/packages/ts-client/src/index.ts
@@ -6,6 +6,8 @@ export type {
   MessageEvents,
   FishjamTrackContext,
   TrackMetadata,
+  Metadata,
+  MetadataDefault,
 } from './types';
 
 export { FishjamClient } from './FishjamClient';

--- a/packages/ts-client/src/index.ts
+++ b/packages/ts-client/src/index.ts
@@ -1,4 +1,13 @@
-export type { Peer, Component, ConnectConfig, CreateConfig, MessageEvents, FishjamTrackContext } from './types';
+export type {
+  Peer,
+  Component,
+  ConnectConfig,
+  CreateConfig,
+  MessageEvents,
+  FishjamTrackContext,
+  TrackMetadata,
+} from './types';
+
 export { FishjamClient } from './FishjamClient';
 
 export type { ReconnectConfig, ReconnectionStatus } from './reconnection';

--- a/packages/ts-client/src/reconnection.ts
+++ b/packages/ts-client/src/reconnection.ts
@@ -55,7 +55,7 @@ export class ReconnectManager<PeerMetadata, TrackMetadata> {
   private removeEventListeners: () => void = () => {};
 
   constructor(
-    client: FishjamClient<PeerMetadata, TrackMetadata>,
+    client: FishjamClient<PeerMetadata>,
     connect: (metadata: PeerMetadata) => void,
     config?: ReconnectConfig | boolean,
   ) {
@@ -63,24 +63,24 @@ export class ReconnectManager<PeerMetadata, TrackMetadata> {
     this.connect = connect;
     this.reconnectConfig = createReconnectConfig(config);
 
-    const onSocketError: MessageEvents<PeerMetadata, TrackMetadata>['socketError'] = () => {
+    const onSocketError: MessageEvents<PeerMetadata>['socketError'] = () => {
       this.reconnect();
     };
     this.client.on('socketError', onSocketError);
 
-    const onConnectionError: MessageEvents<PeerMetadata, TrackMetadata>['connectionError'] = () => {
+    const onConnectionError: MessageEvents<PeerMetadata>['connectionError'] = () => {
       this.reconnect();
     };
     this.client.on('connectionError', onConnectionError);
 
-    const onSocketClose: MessageEvents<PeerMetadata, TrackMetadata>['socketClose'] = (event) => {
+    const onSocketClose: MessageEvents<PeerMetadata>['socketClose'] = (event) => {
       if (isAuthError(event.reason)) return;
 
       this.reconnect();
     };
     this.client.on('socketClose', onSocketClose);
 
-    const onAuthSuccess: MessageEvents<PeerMetadata, TrackMetadata>['authSuccess'] = () => {
+    const onAuthSuccess: MessageEvents<PeerMetadata>['authSuccess'] = () => {
       this.reset(this.initialMetadata! as PeerMetadata);
     };
     this.client.on('authSuccess', onAuthSuccess);

--- a/packages/ts-client/src/reconnection.ts
+++ b/packages/ts-client/src/reconnection.ts
@@ -1,7 +1,7 @@
 import type { Endpoint } from '@fishjam-cloud/webrtc-client';
 import type { FishjamClient } from './FishjamClient';
 import { isAuthError } from './auth';
-import type { MessageEvents } from './types';
+import type { MessageEvents, TrackMetadata } from './types';
 
 export type ReconnectionStatus = 'reconnecting' | 'idle' | 'error';
 
@@ -41,11 +41,11 @@ const DEFAULT_RECONNECT_CONFIG: Required<ReconnectConfig> = {
   addTracksOnReconnect: true,
 };
 
-export class ReconnectManager<PeerMetadata, TrackMetadata> {
+export class ReconnectManager<PeerMetadata> {
   private readonly reconnectConfig: Required<ReconnectConfig>;
 
   private readonly connect: (metadata: PeerMetadata) => void;
-  private readonly client: FishjamClient<PeerMetadata, TrackMetadata>;
+  private readonly client: FishjamClient<PeerMetadata>;
   private initialMetadata: PeerMetadata | undefined | null = undefined;
 
   private reconnectAttempt: number = 0;

--- a/packages/ts-client/src/reconnection.ts
+++ b/packages/ts-client/src/reconnection.ts
@@ -41,11 +41,11 @@ const DEFAULT_RECONNECT_CONFIG: Required<ReconnectConfig> = {
   addTracksOnReconnect: true,
 };
 
-export class ReconnectManager<PeerMetadata> {
+export class ReconnectManager<PeerMetadata, ServerMetadata> {
   private readonly reconnectConfig: Required<ReconnectConfig>;
 
   private readonly connect: (metadata: PeerMetadata) => void;
-  private readonly client: FishjamClient<PeerMetadata>;
+  private readonly client: FishjamClient<PeerMetadata, ServerMetadata>;
   private initialMetadata: PeerMetadata | undefined | null = undefined;
 
   private reconnectAttempt: number = 0;
@@ -55,7 +55,7 @@ export class ReconnectManager<PeerMetadata> {
   private removeEventListeners: () => void = () => {};
 
   constructor(
-    client: FishjamClient<PeerMetadata>,
+    client: FishjamClient<PeerMetadata, ServerMetadata>,
     connect: (metadata: PeerMetadata) => void,
     config?: ReconnectConfig | boolean,
   ) {
@@ -63,25 +63,25 @@ export class ReconnectManager<PeerMetadata> {
     this.connect = connect;
     this.reconnectConfig = createReconnectConfig(config);
 
-    const onSocketError: MessageEvents<PeerMetadata>['socketError'] = () => {
+    const onSocketError: MessageEvents<PeerMetadata, ServerMetadata>['socketError'] = () => {
       this.reconnect();
     };
     this.client.on('socketError', onSocketError);
 
-    const onConnectionError: MessageEvents<PeerMetadata>['connectionError'] = () => {
+    const onConnectionError: MessageEvents<PeerMetadata, ServerMetadata>['connectionError'] = () => {
       this.reconnect();
     };
     this.client.on('connectionError', onConnectionError);
 
-    const onSocketClose: MessageEvents<PeerMetadata>['socketClose'] = (event) => {
+    const onSocketClose: MessageEvents<PeerMetadata, ServerMetadata>['socketClose'] = (event) => {
       if (isAuthError(event.reason)) return;
 
       this.reconnect();
     };
     this.client.on('socketClose', onSocketClose);
 
-    const onAuthSuccess: MessageEvents<PeerMetadata>['authSuccess'] = () => {
-      this.reset(this.initialMetadata! as PeerMetadata);
+    const onAuthSuccess: MessageEvents<PeerMetadata, ServerMetadata>['authSuccess'] = () => {
+      this.reset(this.initialMetadata!);
     };
     this.client.on('authSuccess', onAuthSuccess);
 

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -21,7 +21,7 @@ export type TrackMetadata = {
 export type GenericMetadata = Record<string, unknown> | undefined;
 
 export type Metadata<P = GenericMetadata, S = GenericMetadata> = {
-  peer: P & { displayName?: string };
+  peer: P;
   server: S;
 };
 

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -20,8 +20,10 @@ export type TrackMetadata = {
 
 export type Metadata<P, S> = {
   peer: P;
-  server?: S;
+  server: S;
 };
+
+export type MetadataDefault = Record<string, unknown> | undefined;
 
 type TrackContextEvents = {
   encodingChanged: (context: FishjamTrackContext) => void;
@@ -41,7 +43,7 @@ export interface FishjamTrackContext extends TypedEmitter<TrackContextEvents> {
   readonly encodingReason?: EncodingReason;
 }
 
-export type Peer<PeerMetadata = Record<string, unknown>, ServerMetadata = Record<string, unknown>> = {
+export type Peer<PeerMetadata = MetadataDefault, ServerMetadata = MetadataDefault> = {
   id: string;
   type: string;
   metadata?: Metadata<PeerMetadata, ServerMetadata>;

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -11,9 +11,16 @@ import type {
 import type { AuthErrorReason } from './auth';
 import type { ReconnectConfig } from './reconnection';
 
-export type PeerServerMetadata<PeerMetadata> = {
-  peer: PeerMetadata;
-  server?: Record<string, unknown>;
+export type TrackMetadata = {
+  type: 'camera' | 'microphone' | 'screenShareVideo' | 'screenShareAudio';
+  paused: boolean;
+  // track label used in recordings
+  displayName?: string;
+};
+
+export type Metadata<P, S> = {
+  peer: P;
+  server?: S;
 };
 
 type TrackContextEvents<Metadata> = {
@@ -34,10 +41,10 @@ export interface FishjamTrackContext<Metadata> extends TypedEmitter<TrackContext
   readonly encodingReason?: EncodingReason;
 }
 
-export type Peer<PeerMetadata, TrackMetadata> = {
+export type Peer<PeerMetadata = Record<string, unknown>, ServerMetadata = Record<string, unknown>> = {
   id: string;
   type: string;
-  metadata?: PeerServerMetadata<PeerMetadata>;
+  metadata?: Metadata<PeerMetadata, ServerMetadata>;
   tracks: Map<string, FishjamTrackContext<TrackMetadata>>;
 };
 
@@ -48,7 +55,7 @@ export type Component = Omit<Endpoint, 'type'> & {
 /**
  * Events emitted by the client with their arguments.
  */
-export type MessageEvents<PeerMetadata, TrackMetadata> = {
+export type MessageEvents<PeerMetadata> = {
   /**
    * Emitted when connect method invoked
    *
@@ -97,7 +104,7 @@ export type MessageEvents<PeerMetadata, TrackMetadata> = {
   /**
    * Called when peer was accepted.
    */
-  joined: (peerId: string, peers: Peer<PeerMetadata, TrackMetadata>[], components: Component[]) => void;
+  joined: (peerId: string, peers: Peer<PeerMetadata>[], components: Component[]) => void;
 
   /**
    * Called when peer was not accepted
@@ -134,17 +141,17 @@ export type MessageEvents<PeerMetadata, TrackMetadata> = {
   /**
    * Called each time new peer joins the room.
    */
-  peerJoined: (peer: Peer<PeerMetadata, TrackMetadata>) => void;
+  peerJoined: (peer: Peer<PeerMetadata>) => void;
 
   /**
    * Called each time peer leaves the room.
    */
-  peerLeft: (peer: Peer<PeerMetadata, TrackMetadata>) => void;
+  peerLeft: (peer: Peer<PeerMetadata>) => void;
 
   /**
    * Called each time peer has its metadata updated.
    */
-  peerUpdated: (peer: Peer<PeerMetadata, TrackMetadata>) => void;
+  peerUpdated: (peer: Peer<PeerMetadata>) => void;
 
   /**
    * Called each time new peer joins the room.

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -23,18 +23,18 @@ export type Metadata<P, S> = {
   server?: S;
 };
 
-type TrackContextEvents<Metadata> = {
-  encodingChanged: (context: FishjamTrackContext<Metadata>) => void;
-  voiceActivityChanged: (context: FishjamTrackContext<Metadata>) => void;
+type TrackContextEvents = {
+  encodingChanged: (context: FishjamTrackContext) => void;
+  voiceActivityChanged: (context: FishjamTrackContext) => void;
 };
 
-export interface FishjamTrackContext<Metadata> extends TypedEmitter<TrackContextEvents<Metadata>> {
+export interface FishjamTrackContext extends TypedEmitter<TrackContextEvents> {
   readonly track: MediaStreamTrack | null;
   readonly stream: MediaStream | null;
   readonly endpoint: Endpoint;
   readonly trackId: string;
   readonly simulcastConfig?: SimulcastConfig;
-  readonly metadata?: Metadata;
+  readonly metadata?: TrackMetadata;
   readonly maxBandwidth?: TrackBandwidthLimit;
   readonly vadStatus: VadStatus;
   readonly encoding?: Encoding;
@@ -45,7 +45,7 @@ export type Peer<PeerMetadata = Record<string, unknown>, ServerMetadata = Record
   id: string;
   type: string;
   metadata?: Metadata<PeerMetadata, ServerMetadata>;
-  tracks: Map<string, FishjamTrackContext<TrackMetadata>>;
+  tracks: Map<string, FishjamTrackContext>;
 };
 
 export type Component = Omit<Endpoint, 'type'> & {
@@ -118,25 +118,25 @@ export type MessageEvents<PeerMetadata> = {
    * This callback is always called after {@link MessageEvents.trackAdded}.
    * It informs user that data related to the given track arrives and can be played or displayed.
    */
-  trackReady: (ctx: FishjamTrackContext<TrackMetadata>) => void;
+  trackReady: (ctx: FishjamTrackContext) => void;
 
   /**
    * Called each time the peer which was already in the room, adds new track. Fields track and stream will be set to null.
    * These fields will be set to non-null value in {@link MessageEvents.trackReady}
    */
-  trackAdded: (ctx: FishjamTrackContext<TrackMetadata>) => void;
+  trackAdded: (ctx: FishjamTrackContext) => void;
 
   /**
    * Called when some track will no longer be sent.
    *
    * It will also be called before {@link MessageEvents.peerLeft} for each track of this peer.
    */
-  trackRemoved: (ctx: FishjamTrackContext<TrackMetadata>) => void;
+  trackRemoved: (ctx: FishjamTrackContext) => void;
 
   /**
    * Called each time peer has its track metadata updated.
    */
-  trackUpdated: (ctx: FishjamTrackContext<TrackMetadata>) => void;
+  trackUpdated: (ctx: FishjamTrackContext) => void;
 
   /**
    * Called each time new peer joins the room.
@@ -181,10 +181,7 @@ export type MessageEvents<PeerMetadata> = {
    * @param enabledTracks - list of tracks which will be sent to client from SFU
    * @param disabledTracks - list of tracks which will not be sent to client from SFU
    */
-  tracksPriorityChanged: (
-    enabledTracks: FishjamTrackContext<TrackMetadata>[],
-    disabledTracks: FishjamTrackContext<TrackMetadata>[],
-  ) => void;
+  tracksPriorityChanged: (enabledTracks: FishjamTrackContext[], disabledTracks: FishjamTrackContext[]) => void;
 
   /**
    * Called every time the server estimates client's bandiwdth.

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -18,12 +18,12 @@ export type TrackMetadata = {
   displayName?: string;
 };
 
-export type Metadata<P, S> = {
-  peer: P;
+export type GenericMetadata = Record<string, unknown> | undefined;
+
+export type Metadata<P = GenericMetadata, S = GenericMetadata> = {
+  peer: P & { displayName?: string };
   server: S;
 };
-
-export type MetadataDefault = Record<string, unknown> | undefined;
 
 type TrackContextEvents = {
   encodingChanged: (context: FishjamTrackContext) => void;
@@ -43,7 +43,7 @@ export interface FishjamTrackContext extends TypedEmitter<TrackContextEvents> {
   readonly encodingReason?: EncodingReason;
 }
 
-export type Peer<PeerMetadata = MetadataDefault, ServerMetadata = MetadataDefault> = {
+export type Peer<PeerMetadata = GenericMetadata, ServerMetadata = GenericMetadata> = {
   id: string;
   type: string;
   metadata?: Metadata<PeerMetadata, ServerMetadata>;
@@ -57,7 +57,7 @@ export type Component = Omit<Endpoint, 'type'> & {
 /**
  * Events emitted by the client with their arguments.
  */
-export type MessageEvents<PeerMetadata> = {
+export type MessageEvents<P, S> = {
   /**
    * Emitted when connect method invoked
    *
@@ -106,7 +106,7 @@ export type MessageEvents<PeerMetadata> = {
   /**
    * Called when peer was accepted.
    */
-  joined: (peerId: string, peers: Peer<PeerMetadata>[], components: Component[]) => void;
+  joined: (peerId: string, peers: Peer<P, S>[], components: Component[]) => void;
 
   /**
    * Called when peer was not accepted
@@ -143,17 +143,17 @@ export type MessageEvents<PeerMetadata> = {
   /**
    * Called each time new peer joins the room.
    */
-  peerJoined: (peer: Peer<PeerMetadata>) => void;
+  peerJoined: (peer: Peer<P, S>) => void;
 
   /**
    * Called each time peer leaves the room.
    */
-  peerLeft: (peer: Peer<PeerMetadata>) => void;
+  peerLeft: (peer: Peer<P, S>) => void;
 
   /**
    * Called each time peer has its metadata updated.
    */
-  peerUpdated: (peer: Peer<PeerMetadata>) => void;
+  peerUpdated: (peer: Peer<P, S>) => void;
 
   /**
    * Called each time new peer joins the room.


### PR DESCRIPTION
## Description

Tidy up the metadata generic types.
Remove the `TrackMetadata` generic because we use a certain schema for track metadata.
Allow users to set metadata types using the `usePeers`  hook. 
When the metadata generics are not set, the type for both peer and server metadata is `Record<string, unknown>`.


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
