### PR TITLE
FCE-898 don't play local audio in fishjam chat

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/RoomView.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomView.tsx
@@ -71,7 +71,7 @@ export const RoomView = () => {
                   )}
                 </Fragment>
               );
-            }
+            },
           )}
         </div>
       </section>

--- a/examples/react-client/fishjam-chat/src/components/RoomView.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomView.tsx
@@ -29,12 +29,7 @@ export const RoomView = () => {
         >
           {localPeer && (
             <>
-              <Tile
-                id="You"
-                name="You"
-                videoTrack={localPeer.cameraTrack}
-                audioTrack={localPeer.microphoneTrack}
-              />
+              <Tile id="You" name="You" videoTrack={localPeer.cameraTrack} />
               {localPeer.screenShareVideoTrack && (
                 <Tile
                   id="Your screen share"
@@ -76,7 +71,7 @@ export const RoomView = () => {
                   )}
                 </Fragment>
               );
-            },
+            }
           )}
         </div>
       </section>


### PR DESCRIPTION
## Description

Removes playing local audio from fishjam chat.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
