### PR TITLE
[FCE-930] Add useUpdatePeerMetadata hook

### DIFF
--- a/packages/react-client/src/hooks/public.ts
+++ b/packages/react-client/src/hooks/public.ts
@@ -6,4 +6,5 @@ export { useInitializeDevices } from "./devices/useInitializeDevices";
 export { usePeers } from "./usePeers";
 export { useScreenShare } from "./useScreenShare";
 export { useStatus } from "./useStatus";
+export { useUpdatePeerMetadata } from "./useUpdatePeerMetadata";
 export { useVAD } from "./useVAD";

--- a/packages/react-client/src/hooks/useUpdatePeerMetadata.ts
+++ b/packages/react-client/src/hooks/useUpdatePeerMetadata.ts
@@ -1,0 +1,16 @@
+import { useCallback } from "react";
+import { useFishjamContext } from "./useFishjamContext";
+import type { GenericMetadata } from "@fishjam-cloud/ts-client";
+
+export const useUpdatePeerMetadata = <PeerMetadata = GenericMetadata>() => {
+  const { fishjamClientRef } = useFishjamContext();
+
+  const updatePeerMetadata = useCallback(
+    (peerMetadata: PeerMetadata) => {
+      fishjamClientRef.current.updatePeerMetadata(peerMetadata as GenericMetadata);
+    },
+    [fishjamClientRef],
+  );
+
+  return { updatePeerMetadata };
+};

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -8,6 +8,7 @@ export {
   usePeers,
   useScreenShare,
   useStatus,
+  useUpdatePeerMetadata,
   useVAD,
 } from "./hooks/public";
 export { FishjamProvider } from "./fishjamProvider";


### PR DESCRIPTION
## Description

Add new `useUpdatePeerMetadata` hook, that would allow to update metadata after connection.

I've tested it with small code added in example app - it worked as expected.

## Motivation and Context

Right now it is not possible to update metadata in web sdk.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
