### PR TITLE
Don't generate protobufs in build step

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,8 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Install node dependencies

--- a/.github/workflows/fishjam-chat.yaml
+++ b/.github/workflows/fishjam-chat.yaml
@@ -23,9 +23,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -19,9 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - name: Use Node.js ${{ matrix.node-version }} 🛎️
         uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:
@@ -31,8 +29,6 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,6 +23,7 @@ jobs:
         working-directory: packages/ts-client
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-react-client:
     runs-on: ubuntu-latest
     permissions:
@@ -30,6 +31,8 @@ jobs:
       id-token: write
     steps:
       - uses: actions/checkout@v4
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v3
       # Setup .npmrc file to publish to npm
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,9 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "yarn workspaces foreach -Ap --topological-dev run build",
     "test:unit": "yarn workspace @fishjam-cloud/webrtc-client test",
     "test:e2e": "yarn workspace @fishjam-e2e/webrtc-client-e2e e2e && yarn workspace @fishjam-e2e/react-client-e2e e2e",
+    "gen:proto": "yarn workspace @fishjam-cloud/protobufs gen:proto",
     "tsc": "yarn workspaces foreach -Ap run tsc || echo '❌ Type errors! ❌' ",
     "format": "yarn workspaces foreach -A -p run format || echo '❌ Formatting issues! ❌'",
     "format:check": "yarn workspaces foreach -A -p run format:check",

--- a/packages/protobufs/package.json
+++ b/packages/protobufs/package.json
@@ -10,7 +10,7 @@
     "./fishjamServer": "./fishjam/server_notifications.ts"
   },
   "scripts": {
-    "build": "./protobuf.sh"
+    "gen:proto": "./protobuf.sh"
   },
   "devDependencies": {
     "ts-proto": "^2.2.7",


### PR DESCRIPTION
## Motivation and Context

Protobufs should be generated on demand, not during the build step e.g. on CI.
Also resolves CI issues.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
