### PR TITLE
[FCE-1038] Update types exports (and typedoc) to make `yarn docs` happy

### DIFF
--- a/.github/workflows/node.yaml
+++ b/.github/workflows/node.yaml
@@ -45,3 +45,6 @@ jobs:
 
       - name: Run typecheck 🚓
         run: yarn tsc
+
+      - name: Run docs generation 📘
+        run: yarn docs

--- a/packages/protobufs/typedoc.json
+++ b/packages/protobufs/typedoc.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "includeVersion": true,
-  "entryPoints": ["src/index.ts"],
-  "readme": "none",
   "validation": {
     "notExported": false
   }

--- a/packages/react-client/src/FishjamProvider.tsx
+++ b/packages/react-client/src/FishjamProvider.tsx
@@ -24,7 +24,7 @@ export interface FishjamProviderProps extends PropsWithChildren {
   /**
    * Set preferred constraints.
    * @param {MediaStreamConstraints} constraints - The media stream constraints as defined by the Web API.
-   * @external {@link https://udn.realityripple.com/docs/Web/API/MediaStreamConstraints MediaStreamConstraints}
+   * @see {@link https://udn.realityripple.com/docs/Web/API/MediaStreamConstraints MediaStreamConstraints}
    */
   constraints?: Pick<MediaStreamConstraints, "audio" | "video">;
   /**
@@ -49,7 +49,6 @@ export interface FishjamProviderProps extends PropsWithChildren {
 /**
  * Provides the Fishjam Context
  * @category Components
- * @param
  */
 export function FishjamProvider(props: FishjamProviderProps) {
   const fishjamClientRef = useRef(new FishjamClient({ reconnect: props.reconnect }));

--- a/packages/react-client/src/devices/DeviceManager.ts
+++ b/packages/react-client/src/devices/DeviceManager.ts
@@ -2,7 +2,6 @@ import EventEmitter from "events";
 import type TypedEmitter from "typed-emitter";
 
 import type {
-  DeviceError,
   DeviceManagerStatus,
   DevicesStatus,
   DeviceState,
@@ -10,7 +9,7 @@ import type {
   MediaManager,
   MediaStatus,
 } from "../types/internal";
-import type { DeviceType, PersistLastDeviceHandlers, TrackMiddleware } from "../types/public";
+import type { DeviceError, DeviceType, PersistLastDeviceHandlers, TrackMiddleware } from "../types/public";
 import { parseUserMediaError } from "../utils/errors";
 import { createStorageConfig } from "../utils/localStorage";
 import { setupOnEndedCallback } from "../utils/track";

--- a/packages/react-client/src/devices/mediaInitializer.ts
+++ b/packages/react-client/src/devices/mediaInitializer.ts
@@ -1,4 +1,5 @@
-import type { CurrentDevices, DeviceError } from "../types/internal";
+import type { CurrentDevices } from "../types/internal";
+import type { DeviceError } from "../types/public";
 import { NOT_FOUND_ERROR, OVERCONSTRAINED_ERROR, PERMISSION_DENIED, UNHANDLED_ERROR } from "../utils/errors";
 import { prepareConstraints } from "./constraints";
 

--- a/packages/react-client/src/hooks/devices/useCamera.ts
+++ b/packages/react-client/src/hooks/devices/useCamera.ts
@@ -1,5 +1,4 @@
-import type { DeviceError } from "../../types/internal";
-import type { DeviceItem, TrackMiddleware } from "../../types/public";
+import type { DeviceError, DeviceItem, TrackMiddleware } from "../../types/public";
 import { useDeviceApi } from "../internal/device/useDeviceApi";
 import { useFishjamContext } from "../internal/useFishjamContext";
 

--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -1,5 +1,4 @@
-import type { DeviceError } from "../../types/internal";
-import type { DeviceItem, TrackMiddleware } from "../../types/public";
+import type { DeviceError, DeviceItem, TrackMiddleware } from "../../types/public";
 import { useDeviceApi } from "../internal/device/useDeviceApi";
 import { useFishjamContext } from "../internal/useFishjamContext";
 

--- a/packages/react-client/src/hooks/internal/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/internal/useFishjamClientState.ts
@@ -1,7 +1,7 @@
 import type { Component, FishjamClient, GenericMetadata, MessageEvents, Peer } from "@fishjam-cloud/ts-client";
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 
-import type { PeerId } from "../../types/internal";
+import type { PeerId } from "../../types/public";
 
 const eventNames = [
   "socketClose",

--- a/packages/react-client/src/hooks/useConnection.ts
+++ b/packages/react-client/src/hooks/useConnection.ts
@@ -26,8 +26,6 @@ export interface JoinRoomConfig<PeerMetadata extends GenericMetadata = GenericMe
 export interface UseConnectionResult {
   /**
    * Join room and start streaming camera and microphone
-   *
-   * @param {JoinRoomConfig}
    */
   joinRoom: <PeerMetadata extends GenericMetadata = GenericMetadata>(
     config: JoinRoomConfig<PeerMetadata>,

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -8,8 +8,7 @@ import type {
   TrackMetadata,
 } from "@fishjam-cloud/ts-client";
 
-import type { PeerId } from "../types/internal";
-import type { Track } from "../types/public";
+import type { PeerId, Track } from "../types/public";
 import { useFishjamContext } from "./internal/useFishjamContext";
 
 /**

--- a/packages/react-client/src/hooks/useVAD.ts
+++ b/packages/react-client/src/hooks/useVAD.ts
@@ -1,7 +1,7 @@
 import type { TrackContext, VadStatus } from "@fishjam-cloud/ts-client";
 import { useEffect, useMemo, useState } from "react";
 
-import type { PeerId, TrackId } from "../types/internal";
+import type { PeerId, TrackId } from "../types/public";
 import { useFishjamClientState } from "./internal/useFishjamClientState";
 import { useFishjamContext } from "./internal/useFishjamContext";
 

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -1,6 +1,10 @@
 export { FishjamProvider, type FishjamProviderProps } from "./FishjamProvider";
 export { useCamera, type UseCameraResult } from "./hooks/devices/useCamera";
-export { useInitializeDevices, type UseInitializeDevicesResult } from "./hooks/devices/useInitializeDevices";
+export {
+  useInitializeDevices,
+  type UseInitializeDevicesParams,
+  type UseInitializeDevicesResult,
+} from "./hooks/devices/useInitializeDevices";
 export { useMicrophone, type UseMicrophoneResult } from "./hooks/devices/useMicrophone";
 export { type JoinRoomConfig, useConnection, type UseConnectionResult } from "./hooks/useConnection";
 export { type PeerWithTracks, usePeers, type UsePeersResult } from "./hooks/usePeers";
@@ -8,11 +12,16 @@ export { useScreenShare, type UseScreenshareResult } from "./hooks/useScreenShar
 export { useUpdatePeerMetadata } from "./hooks/useUpdatePeerMetadata";
 export { useVAD } from "./hooks/useVAD";
 export type {
+  BandwidthLimits,
+  DeviceError,
   DeviceItem,
+  PeerId,
   PeerStatus,
   PersistLastDeviceHandlers,
+  SimulcastBandwidthLimits,
   StreamConfig,
   Track,
+  TrackId,
   TrackMiddleware,
   TracksMiddleware,
 } from "./types/public";

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -1,7 +1,4 @@
-import type { DeviceType, Track, TrackMiddleware, TracksMiddleware } from "./public";
-
-export type TrackId = string;
-export type PeerId = string;
+import type { DeviceError, DeviceType, Track, TrackMiddleware, TracksMiddleware } from "./public";
 
 export type DevicesStatus = "OK" | "Error" | "Not requested" | "Requesting";
 export type MediaStatus = "OK" | "Error" | "Not requested" | "Requesting";
@@ -29,12 +26,6 @@ export type DeviceState = {
   error: DeviceError | null;
   currentMiddleware: TrackMiddleware | null;
 };
-
-export type DeviceError =
-  | { name: "OverconstrainedError" }
-  | { name: "NotAllowedError" }
-  | { name: "NotFoundError" }
-  | { name: "UNHANDLED_ERROR" };
 
 export type CurrentDevices = { videoinput: MediaDeviceInfo | null; audioinput: MediaDeviceInfo | null };
 

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -1,6 +1,9 @@
 import type { SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-client";
 
-import type { DeviceError, DeviceManagerStatus, TrackId } from "./internal";
+import type { DeviceManagerStatus } from "./internal";
+
+export type TrackId = string;
+export type PeerId = string;
 
 export type Track = {
   stream: MediaStream | null;
@@ -57,3 +60,9 @@ export type StreamConfig = { simulcast?: Variant[] | false };
 export type BandwidthLimits = { singleStream: number; simulcast: SimulcastBandwidthLimits };
 
 export type DeviceType = "audio" | "video";
+
+export type DeviceError =
+  | { name: "OverconstrainedError" }
+  | { name: "NotAllowedError" }
+  | { name: "NotFoundError" }
+  | { name: "UNHANDLED_ERROR" };

--- a/packages/react-client/src/utils/errors.ts
+++ b/packages/react-client/src/utils/errors.ts
@@ -1,4 +1,4 @@
-import type { DeviceError } from "../types/internal";
+import type { DeviceError } from "../types/public";
 
 export const PERMISSION_DENIED: DeviceError = { name: "NotAllowedError" };
 export const OVERCONSTRAINED_ERROR: DeviceError = { name: "OverconstrainedError" };

--- a/packages/react-client/typedoc.json
+++ b/packages/react-client/typedoc.json
@@ -5,5 +5,8 @@
   "categoryOrder": ["Connection", "Devices", "Screenshare", "Components", "*", "Debugging"],
   "sort": ["kind", "alphabetical"],
   "kindSortOrder": ["Method", "Function"],
-  "readme": "none"
+  "readme": "none",
+  "validation": {
+    "notExported": true
+  }
 }

--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -101,7 +101,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
   }
 
   /**
-   * Uses the {@link !WebSocket} connection and {@link !WebRTCEndpoint | WebRTCEndpoint} to join to the room. Registers the callbacks to
+   * Uses the WebSocket connection and {@link !WebRTCEndpoint | WebRTCEndpoint} to join to the room. Registers the callbacks to
    * handle the events emitted by the {@link !WebRTCEndpoint | WebRTCEndpoint}. Make sure that peer metadata is serializable.
    *
    * @example
@@ -214,7 +214,6 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
    *
    * @return {Promise<RTCStatsReport>}
    *
-   * @external RTCPeerConnection#getStats()
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats | MDN Web Docs: RTCPeerConnection.getStats()}
    */
   public async getStatistics(selector?: MediaStreamTrack | null): Promise<RTCStatsReport> {

--- a/packages/ts-client/src/index.ts
+++ b/packages/ts-client/src/index.ts
@@ -11,6 +11,7 @@ export type {
   MessageEvents,
   Metadata,
   Peer,
+  TrackContextEvents,
   TrackMetadata,
 } from './types';
 export type {
@@ -21,7 +22,6 @@ export type {
   SimulcastConfig,
   TrackBandwidthLimit,
   TrackContext,
-  TrackContextEvents,
   VadStatus,
   WebRTCEndpointEvents,
 } from '@fishjam-cloud/webrtc-client';

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -32,7 +32,7 @@ export type Metadata<PeerMetadata = GenericMetadata, ServerMetadata = GenericMet
   server: ServerMetadata;
 };
 
-type TrackContextEvents = {
+export type TrackContextEvents = {
   encodingChanged: (context: FishjamTrackContext) => void;
   voiceActivityChanged: (context: FishjamTrackContext) => void;
 };

--- a/packages/webrtc-client/src/webRTCEndpoint.ts
+++ b/packages/webrtc-client/src/webRTCEndpoint.ts
@@ -157,7 +157,6 @@ export class WebRTCEndpoint extends (EventEmitter as new () => TypedEmitter<Requ
    *
    * @return {Promise<RTCStatsReport>}
    *
-   * @external RTCPeerConnection#getStats()
    * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/getStats | MDN Web Docs: RTCPeerConnection.getStats()}
    */
   public async getStatistics(selector?: MediaStreamTrack | null): Promise<RTCStatsReport> {

--- a/typedoc.json
+++ b/typedoc.json
@@ -6,5 +6,7 @@
   "plugin": ["typedoc-material-theme"],
   "themeColor": "#FCF6E7",
   "sort": ["kind", "alphabetical"],
-  "kindSortOrder": ["Method", "Function"]
+  "kindSortOrder": ["Method", "Function"],
+  "treatValidationWarningsAsErrors": true,
+  "treatWarningsAsErrors": true
 }


### PR DESCRIPTION
## Description

Export all types that are visible to end user, but were not yet exported
Fix typedoc syntax marked as incorrect
Update typedoc config to avoid part of validation for libraries that are not actively supported

## Motivation and Context

I want to update our documentation, but as part of this process I want to remove warnings (and also add missing types into docs)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
