### PR TITLE
[FCE-1057] Add branded PeerId and TrackId

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/RoomView.tsx
+++ b/examples/react-client/fishjam-chat/src/components/RoomView.tsx
@@ -38,7 +38,7 @@ export const RoomView = () => {
               />
               {localPeer.screenShareVideoTrack && (
                 <Tile
-                  id="Your screen share"
+                  id={localPeer.id}
                   name="Your screen share"
                   videoTrack={localPeer.screenShareVideoTrack}
                   audioTrack={localPeer.screenShareAudioTrack}

--- a/examples/react-client/fishjam-chat/src/components/Tile.tsx
+++ b/examples/react-client/fishjam-chat/src/components/Tile.tsx
@@ -1,11 +1,11 @@
-import { type Track, useVAD } from "@fishjam-cloud/react-client";
+import { type PeerId, type Track, useVAD } from "@fishjam-cloud/react-client";
 
 import AudioPlayer from "./AudioPlayer";
 import { Badge } from "./ui/badge";
 import VideoPlayer from "./VideoPlayer";
 
 type Props = {
-  id: string;
+  id: PeerId;
   name: string;
   videoTrack?: Track;
   audioTrack?: Track;

--- a/packages/react-client/src/hooks/internal/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/internal/useFishjamClientState.ts
@@ -1,6 +1,7 @@
-import type { Component, FishjamClient, GenericMetadata, MessageEvents, Peer } from "@fishjam-cloud/ts-client";
+import type { Component, FishjamClient, GenericMetadata, MessageEvents } from "@fishjam-cloud/ts-client";
 import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
 
+import type { BrandedPeer } from "../../types/internal";
 import type { PeerId } from "../../types/public";
 
 const eventNames = [
@@ -44,9 +45,9 @@ const eventNames = [
 ] as const satisfies (keyof MessageEvents<unknown, unknown>)[];
 
 export interface FishjamClientState<P = GenericMetadata, S = GenericMetadata> {
-  peers: Record<PeerId, Peer<P, S>>;
+  peers: Record<PeerId, BrandedPeer<P, S>>;
   components: Record<string, Component>;
-  localPeer: Peer<P, S> | null;
+  localPeer: BrandedPeer<P, S> | null;
   isReconnecting: boolean;
 }
 
@@ -82,9 +83,9 @@ export function useFishjamClientState<P, S>(fishjamClient: FishjamClient<P, S>):
       const isReconnecting = client.isReconnecting();
 
       lastSnapshotRef.current = {
-        peers,
+        peers: peers as Record<PeerId, BrandedPeer<P, S>>,
         components,
-        localPeer,
+        localPeer: localPeer as BrandedPeer<P, S>,
         isReconnecting,
       };
       mutationRef.current = false;

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,13 +1,6 @@
-import type {
-  Component,
-  Endpoint,
-  FishjamTrackContext,
-  Metadata,
-  Peer,
-  TrackContext,
-  TrackMetadata,
-} from "@fishjam-cloud/ts-client";
+import type { FishjamTrackContext, Metadata, Peer, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
 
+import type { BrandedPeer } from "../types/internal";
 import type { PeerId, Track } from "../types/public";
 import { useFishjamContext } from "./internal/useFishjamContext";
 
@@ -38,7 +31,7 @@ function trackContextToTrack(track: FishjamTrackContext | TrackContext): Track {
   };
 }
 
-function getPeerWithDistinguishedTracks<P, S>(peer: Peer<P, S> | Component | Endpoint): PeerWithTracks<P, S> {
+function getPeerWithDistinguishedTracks<P, S>(peer: BrandedPeer<P, S>): PeerWithTracks<P, S> {
   const tracks = [...peer.tracks.values()].map(trackContextToTrack);
 
   const cameraTrack = tracks.find(({ metadata }) => metadata?.type === "camera");
@@ -98,11 +91,13 @@ export function usePeers<
   const { clientState } = useFishjamContext();
 
   const localPeer = clientState.localPeer
-    ? getPeerWithDistinguishedTracks<PeerMetadata, ServerMetadata>(clientState.localPeer)
+    ? getPeerWithDistinguishedTracks<PeerMetadata, ServerMetadata>(
+        clientState.localPeer as BrandedPeer<PeerMetadata, ServerMetadata>,
+      )
     : null;
 
   const remotePeers = Object.values(clientState.peers).map((peer) =>
-    getPeerWithDistinguishedTracks<PeerMetadata, ServerMetadata>(peer),
+    getPeerWithDistinguishedTracks<PeerMetadata, ServerMetadata>(peer as BrandedPeer<PeerMetadata, ServerMetadata>),
   );
 
   return { localPeer, remotePeers, peers: remotePeers };

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,7 +1,7 @@
 import type { FishjamTrackContext, Metadata, Peer, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
 
 import type { BrandedPeer } from "../types/internal";
-import type { PeerId, Track } from "../types/public";
+import type { PeerId, Track, TrackId } from "../types/public";
 import { useFishjamContext } from "./internal/useFishjamContext";
 
 /**
@@ -23,7 +23,7 @@ export type PeerWithTracks<PeerMetadata, ServerMetadata> = {
 function trackContextToTrack(track: FishjamTrackContext | TrackContext): Track {
   return {
     metadata: track.metadata as TrackMetadata,
-    trackId: track.trackId,
+    trackId: track.trackId as TrackId,
     stream: track.stream,
     simulcastConfig: track.simulcastConfig ?? null,
     encoding: track.encoding ?? null,

--- a/packages/react-client/src/index.ts
+++ b/packages/react-client/src/index.ts
@@ -13,6 +13,7 @@ export { useUpdatePeerMetadata } from "./hooks/useUpdatePeerMetadata";
 export { useVAD } from "./hooks/useVAD";
 export type {
   BandwidthLimits,
+  Brand,
   DeviceError,
   DeviceItem,
   PeerId,

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -1,4 +1,6 @@
-import type { DeviceError, DeviceType, Track, TrackMiddleware, TracksMiddleware } from "./public";
+import type { Peer } from "@fishjam-cloud/ts-client";
+
+import type { DeviceError, DeviceType, PeerId, Track, TrackMiddleware, TracksMiddleware } from "./public";
 
 export type DevicesStatus = "OK" | "Error" | "Not requested" | "Requesting";
 export type MediaStatus = "OK" | "Error" | "Not requested" | "Requesting";
@@ -72,3 +74,5 @@ export interface TrackManager {
    */
   toggleDevice: () => Promise<void>;
 }
+
+export type BrandedPeer<P, S> = Omit<Peer<P, S>, "id"> & { id: PeerId };

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -2,7 +2,7 @@ import type { SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-
 
 import type { DeviceManagerStatus } from "./internal";
 
-export type TrackId = string;
+export type TrackId = Brand<string, "TrackId">;;
 export type PeerId = Brand<string, "PeerId">;
 
 export type Track = {

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -2,7 +2,7 @@ import type { SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-
 
 import type { DeviceManagerStatus } from "./internal";
 
-export type TrackId = Brand<string, "TrackId">;;
+export type TrackId = Brand<string, "TrackId">;
 export type PeerId = Brand<string, "PeerId">;
 
 export type Track = {
@@ -68,4 +68,4 @@ export type DeviceError =
   | { name: "UNHANDLED_ERROR" };
 
 declare const brand: unique symbol;
-type Brand<T, TBrand extends string> = T & { [brand]: TBrand };
+export type Brand<T, TBrand extends string> = T & { [brand]: TBrand };

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -3,7 +3,7 @@ import type { SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-
 import type { DeviceManagerStatus } from "./internal";
 
 export type TrackId = string;
-export type PeerId = string;
+export type PeerId = Brand<string, "PeerId">;
 
 export type Track = {
   stream: MediaStream | null;
@@ -66,3 +66,6 @@ export type DeviceError =
   | { name: "NotAllowedError" }
   | { name: "NotFoundError" }
   | { name: "UNHANDLED_ERROR" };
+
+declare const brand: unique symbol;
+type Brand<T, TBrand extends string> = T & { [brand]: TBrand };

--- a/packages/react-client/src/utils/track.ts
+++ b/packages/react-client/src/utils/track.ts
@@ -1,7 +1,7 @@
 import type { FishjamClient, SimulcastConfig, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
 import { Variant } from "@fishjam-cloud/ts-client";
 
-import type { BandwidthLimits, Track } from "../types/public";
+import type { BandwidthLimits, Track, TrackId } from "../types/public";
 
 // In most cases, the track is identified by its remote track ID.
 // This ID comes from the ts-client `addTrack` method.
@@ -29,7 +29,7 @@ const getRemoteOrLocalTrackContext = <PeerMetadata>(
 
 const getTrackFromContext = (context: TrackContext): Track => ({
   metadata: context.metadata as TrackMetadata,
-  trackId: context.trackId,
+  trackId: context.trackId as TrackId,
   stream: context.stream,
   simulcastConfig: context.simulcastConfig || null,
   encoding: context.encoding || null,


### PR DESCRIPTION
## Description

Add branded types to most common IDs used in React Client. This way, these IDs can't be used as strings.

## Motivation and Context

Make client code a little less buggy

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
