### PR TITLE
FCE-1059/fix reconnection manager endpoint metadata retrieval

### DIFF
--- a/packages/ts-client/src/reconnection.ts
+++ b/packages/ts-client/src/reconnection.ts
@@ -2,7 +2,7 @@ import type { Endpoint } from '@fishjam-cloud/webrtc-client';
 
 import { isAuthError } from './auth';
 import type { FishjamClient } from './FishjamClient';
-import type { MessageEvents, TrackMetadata } from './types';
+import type { MessageEvents, Metadata, TrackMetadata } from './types';
 
 export type ReconnectionStatus = 'reconnecting' | 'idle' | 'error';
 
@@ -104,9 +104,7 @@ export class ReconnectManager<PeerMetadata, ServerMetadata> {
   }
 
   private getLastPeerMetadata(): PeerMetadata | undefined {
-    const endpointMetadata = this.lastLocalEndpoint?.metadata as
-      | { peer: PeerMetadata; server: ServerMetadata }
-      | undefined;
+    const endpointMetadata = this.lastLocalEndpoint?.metadata as Metadata<PeerMetadata, ServerMetadata> | undefined;
     return endpointMetadata?.peer;
   }
 


### PR DESCRIPTION
## Description

Fixes low level peer metadata retrieval from RTC Endpoint.

## Motivation and Context

The tsclient's `ReconnectionManager` was still unaware of the metadata being divided between peer and server.
The type of the metadata at the `LocalTrack` level is `unknown` and `ReconnectionManager` was wrongfully casting it as `PeerMetadata`.
This led to issues with providing correct metadata while reconnecting.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
