### PR TITLE
[FCE-1082] - Fix generated output of TrackContextImpl

### DIFF
--- a/packages/webrtc-client/src/internal.ts
+++ b/packages/webrtc-client/src/internal.ts
@@ -20,23 +20,20 @@ export class TrackContextImpl
   extends (EventEmitter as new () => TypedEmitter<Required<TrackContextEvents>>)
   implements TrackContext
 {
-  endpoint: Endpoint;
-  trackId: string;
-  track: MediaStreamTrack | null = null;
-  trackKind: TrackKind | null = null;
-  stream: MediaStream | null = null;
-  metadata?: unknown;
-  metadataParsingError?: any;
-  simulcastConfig?: MediaEvent_Track_SimulcastConfig;
-  maxBandwidth: TrackBandwidthLimit = 0;
-  encoding?: Variant;
-  encodingReason?: EncodingReason;
-  vadStatus: VadStatus = 'silence';
-  negotiationStatus: TrackNegotiationStatus = 'awaiting';
-
-  // Indicates that metadata were changed when in "offered" negotiationStatus
-  // and `updateTrackMetadata` Media Event should be sent after the transition to "done"
-  pendingMetadataUpdate: boolean = false;
+  declare endpoint: Endpoint;
+  declare trackId: string;
+  declare track: MediaStreamTrack | null;
+  declare trackKind: TrackKind | null;
+  declare stream: MediaStream | null;
+  declare metadata?: unknown;
+  declare metadataParsingError?: any;
+  declare simulcastConfig?: MediaEvent_Track_SimulcastConfig;
+  declare maxBandwidth: TrackBandwidthLimit;
+  declare encoding?: Variant;
+  declare encodingReason?: EncodingReason;
+  declare vadStatus: VadStatus;
+  declare negotiationStatus: TrackNegotiationStatus;
+  declare pendingMetadataUpdate: boolean;
 
   constructor(
     endpoint: Endpoint,
@@ -47,8 +44,15 @@ export class TrackContextImpl
     super();
     this.endpoint = endpoint;
     this.trackId = trackId;
+    this.track = null;
+    this.trackKind = null;
+    this.stream = null;
     this.metadata = metadata;
     this.simulcastConfig = simulcastConfig;
+    this.maxBandwidth = 0;
+    this.vadStatus = 'silence';
+    this.negotiationStatus = 'awaiting';
+    this.pendingMetadataUpdate = false;
   }
 }
 

--- a/packages/webrtc-client/src/internal.ts
+++ b/packages/webrtc-client/src/internal.ts
@@ -33,6 +33,8 @@ export class TrackContextImpl
   declare encodingReason?: EncodingReason;
   declare vadStatus: VadStatus;
   declare negotiationStatus: TrackNegotiationStatus;
+  // Indicates that metadata were changed when in "offered" negotiationStatus
+  // and `updateTrackMetadata` Media Event should be sent after the transition to "done"
   declare pendingMetadataUpdate: boolean;
 
   constructor(


### PR DESCRIPTION
## Description

- Refactored TrackContextImpl to avoid runtime errors caused by useDefineForClassFields.

## Motivation and Context

Our tsconfig either enables `useDefineForClassFields` or sets `target: es2022` (enabling it by default). This can cause issues when subclassing, as this may be used before `super()` is called. More details [here](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#the-usedefineforclassfields-flag-and-the-declare-property-modifier). 
This caused runtime errors with `WebRTCEndpoint`, especially in Playwright tests for `membrane-rtc-engine`.

We have two options:

1. Disable `useDefineForClassFields`, which is risky and could impact the codebase.
2. Refactor `TrackContextImpl` using declare to modify JS output and move initialization to the constructor.

I chose option 2 as it is less invasive and resolves the issue safely.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
