### PR TITLE
[FCE-1126] Update publish docs action

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Use corepack
         run: corepack enable
       - name: Install node dependencies
@@ -42,10 +42,10 @@ jobs:
       - name: Run typedoc
         run: yarn docs
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           # Upload entire repository
           path: "docs"
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Description

Update all actions related to publishing docs for this project

## Motivation and Context

As of today, [actions/upload-artifact](https://github.com/actions/upload-artifact) is no longer available. So we have to update all actions that depend on it.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
