### PR TITLE
FCE-1205/stale closure in track manager

### DIFF
--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -26,7 +26,8 @@ export function useMicrophone() {
     isMicrophoneOn: !!deviceApi.mediaStream,
     /**
      * Indicates whether the microphone is muted
-     */ isMicrophoneMuted: audioTrackManager.paused,
+     */
+    isMicrophoneMuted: audioTrackManager.paused,
     /**
      * The MediaStream object containing the current audio stream
      */

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -1,6 +1,6 @@
 import type { Peer } from "@fishjam-cloud/ts-client";
 
-import type { DeviceError, DeviceType, PeerId, Track, TrackMiddleware, TracksMiddleware } from "./public";
+import type { DeviceError, DeviceType, PeerId, TrackMiddleware, TracksMiddleware } from "./public";
 
 export type DevicesStatus = "OK" | "Error" | "Not requested" | "Requesting";
 export type MediaStatus = "OK" | "Error" | "Not requested" | "Requesting";
@@ -54,8 +54,6 @@ export interface TrackManager {
   selectDevice: (deviceId?: string) => Promise<void>;
   paused: boolean;
   setTrackMiddleware: (middleware: TrackMiddleware | null) => Promise<void>;
-  currentTrack: Track | null;
-
   /**
    * Either enables or disables the stream.
    *


### PR DESCRIPTION
## Description

Removes a stale closure from track manager and stop exposing `currentTrack` as it's not consumed anywhere.

## Motivation and Context

Calling `toggleCamera` after leaving a room caused an exception, because the closure contained stale state which still had a `currentTrack`.
