### PR TITLE
Fce 1279/patch race conditions and poor cleanup

### DIFF
--- a/packages/react-client/src/FishjamProvider.tsx
+++ b/packages/react-client/src/FishjamProvider.tsx
@@ -53,7 +53,8 @@ export interface FishjamProviderProps extends PropsWithChildren {
 export function FishjamProvider(props: FishjamProviderProps) {
   const fishjamClientRef = useRef(new FishjamClient({ reconnect: props.reconnect }));
 
-  const hasDevicesBeenInitializedRef = useRef(false);
+  const devicesInitializationRef = useRef<Promise<void> | null>(null);
+
   const storage = props.persistLastDevice;
 
   const videoDeviceManagerRef = useRef(
@@ -84,6 +85,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
     getCurrentPeerStatus,
     bandwidthLimits: mergedBandwidthLimits,
     streamConfig: props.videoConfig,
+    devicesInitializationRef,
   });
 
   const audioTrackManager = useTrackManager({
@@ -92,6 +94,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
     getCurrentPeerStatus,
     bandwidthLimits: mergedBandwidthLimits,
     streamConfig: props.audioConfig,
+    devicesInitializationRef,
   });
 
   const screenShareManager = useScreenShareManager({ fishjamClient: fishjamClientRef.current, getCurrentPeerStatus });
@@ -106,7 +109,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
     audioTrackManager,
     videoDeviceManagerRef,
     audioDeviceManagerRef,
-    hasDevicesBeenInitializedRef,
+    devicesInitializationRef,
     clientState,
     bandwidthLimits: mergedBandwidthLimits,
   };

--- a/packages/react-client/src/devices/DeviceManager.ts
+++ b/packages/react-client/src/devices/DeviceManager.ts
@@ -242,6 +242,7 @@ export class DeviceManager
     this.middlewareManager.clearMiddleware();
     this.processedMediaTrack?.stop();
     this.rawMedia?.track?.stop();
+    this.media?.track?.stop();
 
     this.updateMedia(null);
 

--- a/packages/react-client/src/devices/DeviceManager.ts
+++ b/packages/react-client/src/devices/DeviceManager.ts
@@ -178,22 +178,8 @@ export class DeviceManager
         this.saveLastDevice?.(deviceInfo);
       }
 
-      // The device manager assumes that there is only one audio and video track.
-      // All previous tracks are deactivated even if the browser is able to handle multiple active sessions. (Chrome, Firefox)
-      //
-      // Safari always deactivates the track and emits the `ended` event.
-      // Its handling is asynchronous and can be executed even before returning a value from the re-execution of `getUserMedia`.
-      // In such a case, the tracks are already deactivated at this point (logic in `onTrackEnded` method).
-      // The track is null, so the stop method will not execute.
-      //
-      // However, if Safari has not yet handled this event, the tracks are manually stopped at this point.
-      // Manually stopping tracks on its own does not generate the `ended` event.
-      // The ended event in Safari has already been emitted and will be handled in the future.
-      // Therefore, in the `onTrackEnded` method, events for already stopped tracks are filtered out to prevent the state from being damaged.
-      if (shouldReplaceDevice) {
-        this.rawMedia?.track?.stop();
-        this.processedMediaTrack?.stop();
-      }
+      this.rawMedia?.track?.stop();
+      this.processedMediaTrack?.stop();
 
       this.updateMedia({
         stream,

--- a/packages/react-client/src/hooks/devices/useCamera.ts
+++ b/packages/react-client/src/hooks/devices/useCamera.ts
@@ -15,6 +15,14 @@ export function useCamera() {
      */
     toggleCamera: videoTrackManager.toggleDevice,
     /**
+     * Toggles current camera on
+     */
+    enableCamera: videoTrackManager.enableDevice,
+    /**
+     * Toggles current camera off
+     */
+    disableCamera: videoTrackManager.disableDevice,
+    /**
      * Selects the camera device
      */
     selectCamera: videoTrackManager.selectDevice,

--- a/packages/react-client/src/hooks/devices/useInitializeDevices.ts
+++ b/packages/react-client/src/hooks/devices/useInitializeDevices.ts
@@ -4,6 +4,7 @@ import { prepareConstraints } from "../../devices/constraints";
 import { correctDevicesOnSafari, getAvailableMedia } from "../../devices/mediaInitializer";
 import { type DeviceError } from "../../types/public";
 import { useFishjamContext } from "../internal/useFishjamContext";
+import { Deferred } from "../../utils/deferred";
 
 export type UseInitializeDevicesParams = {
   enableVideo?: boolean;
@@ -23,11 +24,10 @@ export const useInitializeDevices = () => {
     useCallback(
       async ({ enableVideo = true, enableAudio = true }: UseInitializeDevicesParams = {}) => {
         if (devicesInitializationRef.current) return null;
-        let resolveInitialization: () => void = () => null;
 
-        devicesInitializationRef.current = new Promise((resolve) => {
-          resolveInitialization = resolve;
-        });
+        const deferred = new Deferred<void>();
+
+        devicesInitializationRef.current = deferred.promise;
 
         const videoManager = videoDeviceManagerRef.current;
         const audioManager = audioDeviceManagerRef.current;
@@ -79,7 +79,8 @@ export const useInitializeDevices = () => {
           deviceErrors.audio,
         );
 
-        resolveInitialization();
+        deferred.resolve();
+
         if (deviceErrors.video || deviceErrors.audio) return deviceErrors;
         return null;
       },

--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -14,6 +14,10 @@ export function useMicrophone() {
     toggleMicrophone: audioTrackManager.toggleDevice,
     /** Mutes/unmutes the microphone */
     toggleMicrophoneMute: audioTrackManager.toggleMute,
+    /** Toggles current microphone on */
+    enableMicrophone: audioTrackManager.enableDevice,
+    /** Toggles current microphone off */
+    disableMicrophone: audioTrackManager.disableDevice,
     /** Selects the microphone device */
     selectMicrophone: audioTrackManager.selectDevice,
     /**

--- a/packages/react-client/src/hooks/internal/useFishjamContext.ts
+++ b/packages/react-client/src/hooks/internal/useFishjamContext.ts
@@ -1,5 +1,5 @@
 import type { FishjamClient } from "@fishjam-cloud/ts-client";
-import { createContext, type MutableRefObject, useContext } from "react";
+import { createContext, type RefObject, useContext } from "react";
 
 import type { DeviceManager } from "../../devices/DeviceManager";
 import type { TrackManager } from "../../types/internal";
@@ -8,10 +8,10 @@ import type { FishjamClientState } from "./useFishjamClientState";
 import type { UseScreenshareResult } from "./useScreenshareManager";
 
 export type FishjamContextType = {
-  fishjamClientRef: MutableRefObject<FishjamClient>;
-  videoDeviceManagerRef: MutableRefObject<DeviceManager>;
-  audioDeviceManagerRef: MutableRefObject<DeviceManager>;
-  hasDevicesBeenInitializedRef: MutableRefObject<boolean>;
+  fishjamClientRef: RefObject<FishjamClient>;
+  videoDeviceManagerRef: RefObject<DeviceManager>;
+  audioDeviceManagerRef: RefObject<DeviceManager>;
+  devicesInitializationRef: RefObject<Promise<void> | null>;
   screenShareManager: UseScreenshareResult;
   peerStatus: PeerStatus;
   videoTrackManager: TrackManager;

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -71,6 +71,8 @@ export interface TrackManager {
    *   - If stopped: starts the device and begins (or resumes) streaming.
    */
   toggleDevice: () => Promise<void>;
+  enableDevice: () => Promise<void>;
+  disableDevice: () => Promise<void>;
 }
 
 export type BrandedPeer<P, S> = Omit<Peer<P, S>, "id"> & { id: PeerId };

--- a/packages/react-client/src/utils/deferred.ts
+++ b/packages/react-client/src/utils/deferred.ts
@@ -1,0 +1,21 @@
+export class Deferred<T, E = unknown> {
+  public promise: Promise<T>;
+
+  private resolveFn: (value: PromiseLike<T> | T) => void = () => null;
+  private rejectFn: (reason?: E) => void = () => null;
+
+  constructor() {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolveFn = resolve;
+      this.rejectFn = reject;
+    });
+  }
+
+  public resolve(value: T) {
+    this.resolveFn(value);
+  }
+
+  public reject(reason?: E) {
+    this.rejectFn(reason);
+  }
+}


### PR DESCRIPTION
## Description

This PR mitigates the issue of starting multiple streams and being unable to stop them later.
The camera is now working correctly in `React.StrictMode`.

Please aware that this is rather **a hack** and a rewrite of the Device Manager is already planned.

## Motivation and Context

Due to StrictMode nature, the DeviceManager's `start` function was called twice, leading to 2 streams being retrieved from the browser, while only one was manageable.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
