### PR TITLE
Filter tracks based on room type

### DIFF
--- a/packages/react-client/src/hooks/internal/useScreenshareManager.ts
+++ b/packages/react-client/src/hooks/internal/useScreenshareManager.ts
@@ -1,4 +1,4 @@
-import type { FishjamClient } from "@fishjam-cloud/ts-client";
+import { type FishjamClient, type TrackMetadata, TrackTypeError } from "@fishjam-cloud/ts-client";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ScreenShareState } from "../../types/internal";
@@ -63,6 +63,18 @@ export const useScreenShareManager = ({
     if (typeof name === "string") return name;
   };
 
+  const addTrackToFishjamClient = async (track: MediaStreamTrack, trackMetadata: TrackMetadata) => {
+    try {
+      return fishjamClient.addTrack(track, trackMetadata);
+    } catch (err) {
+      if (err instanceof TrackTypeError) {
+        console.warn(err.message);
+        return undefined;
+      }
+      throw err;
+    }
+  };
+
   const startStreaming: UseScreenshareResult["startStreaming"] = async (props) => {
     const displayStream = await navigator.mediaDevices.getDisplayMedia({
       video: props?.videoConstraints ?? true,
@@ -80,9 +92,9 @@ export const useScreenShareManager = ({
       cleanMiddlewareFnRef.current = onClear;
     }
 
-    const addTrackPromises = [fishjamClient.addTrack(video, { displayName, type: "screenShareVideo", paused: false })];
+    const addTrackPromises = [addTrackToFishjamClient(video, { displayName, type: "screenShareVideo", paused: false })];
     if (audio)
-      addTrackPromises.push(fishjamClient.addTrack(audio, { displayName, type: "screenShareAudio", paused: false }));
+      addTrackPromises.push(addTrackToFishjamClient(audio, { displayName, type: "screenShareAudio", paused: false }));
 
     const [videoId, audioId] = await Promise.all(addTrackPromises);
     setState({ stream: displayStream, trackIds: { videoId, audioId } });
@@ -91,11 +103,12 @@ export const useScreenShareManager = ({
   const replaceTracks = async (newVideoTrack: MediaStreamTrack, newAudioTrack: MediaStreamTrack | null) => {
     if (!state?.stream) return;
 
-    const addTrackPromises = [fishjamClient.replaceTrack(state.trackIds.videoId, newVideoTrack)];
+    const addTrackPromises: Promise<void>[] = [];
 
-    if (newAudioTrack && state.trackIds.audioId) {
+    if (newVideoTrack && state.trackIds.videoId)
+      addTrackPromises.push(fishjamClient.replaceTrack(state.trackIds.videoId, newVideoTrack));
+    if (newAudioTrack && state.trackIds.audioId)
       addTrackPromises.push(fishjamClient.replaceTrack(state.trackIds.audioId, newAudioTrack));
-    }
 
     await Promise.all(addTrackPromises);
   };
@@ -132,7 +145,8 @@ export const useScreenShareManager = ({
     if (audio) audio.stop();
 
     if (getCurrentPeerStatus() === "connected") {
-      const removeTrackPromises = [fishjamClient.removeTrack(state.trackIds.videoId)];
+      const removeTrackPromises: Promise<void>[] = [];
+      if (state.trackIds.videoId) removeTrackPromises.push(fishjamClient.removeTrack(state.trackIds.videoId));
       if (state.trackIds.audioId) removeTrackPromises.push(fishjamClient.removeTrack(state.trackIds.audioId));
 
       await Promise.all(removeTrackPromises);

--- a/packages/react-client/src/hooks/internal/useTrackManager.ts
+++ b/packages/react-client/src/hooks/internal/useTrackManager.ts
@@ -91,6 +91,7 @@ export const useTrackManager = ({
       } catch (err) {
         if (err instanceof TrackTypeError) {
           console.warn(err.message);
+          currentTrackIdRef.current = null;
           return null;
         }
         throw err;

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -45,7 +45,7 @@ export interface MediaManager {
 export type ScreenShareState = (
   | {
       stream: MediaStream;
-      trackIds: { videoId: string; audioId?: string };
+      trackIds: { videoId?: string; audioId?: string };
     }
   | { stream: null; trackIds: null }
 ) & { tracksMiddleware?: TracksMiddleware | null };

--- a/packages/ts-client/src/errors.ts
+++ b/packages/ts-client/src/errors.ts
@@ -1,5 +1,7 @@
 export class TrackTypeError extends Error {
-  constructor(trackType: string, allowedTrackTypes: string[]) {
-    super(`Attempted to add ${trackType} track to room which only supports ${allowedTrackTypes.join(', ')}`);
+  constructor() {
+    super(
+      `Attempted to add video track to audio-only room. Please refer to the docs at https://docs.fishjam.io/audio-calls`,
+    );
   }
 }

--- a/packages/ts-client/src/errors.ts
+++ b/packages/ts-client/src/errors.ts
@@ -1,0 +1,5 @@
+export class TrackTypeError extends Error {
+  constructor(trackType: string, allowedTrackTypes: string[]) {
+    super(`Attempted to add ${trackType} track to room which only supports ${allowedTrackTypes.join(', ')}`);
+  }
+}

--- a/packages/ts-client/src/index.ts
+++ b/packages/ts-client/src/index.ts
@@ -1,4 +1,5 @@
 export { AUTH_ERROR_REASONS, type AuthErrorReason, isAuthError } from './auth.js';
+export { TrackTypeError } from './errors';
 export { FishjamClient } from './FishjamClient';
 export { isJoinError, JOIN_ERRORS, type JoinErrorReason } from './guards';
 export type { ReconnectConfig, ReconnectionStatus } from './reconnection';

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -3,7 +3,6 @@ import type {
   Endpoint,
   SimulcastConfig,
   TrackBandwidthLimit,
-  TrackKind,
   VadStatus,
   Variant,
   WebRTCEndpointEvents,

--- a/packages/ts-client/src/types.ts
+++ b/packages/ts-client/src/types.ts
@@ -3,6 +3,7 @@ import type {
   Endpoint,
   SimulcastConfig,
   TrackBandwidthLimit,
+  TrackKind,
   VadStatus,
   Variant,
   WebRTCEndpointEvents,


### PR DESCRIPTION
## Description

`FishjamClient.addTrack` now checks if the track kind is allowed for the given room type and throws an error if it's not allowed.
`react-client` handles this error, i.e. the track is not added and a warning is logged to the console

## Motivation and Context

This aims to give users better feedback when they attempt to add a video track to an audio-only room, as until now the behavior is that the peer joins the room and after a few seconds the entire `PeerConnection` crashes abruptly without any reasonable logs.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
