### PR TITLE
Make webrtc package public

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,26 @@ on:
   release:
     types: [published]
 jobs:
+  publish-webrtc-client:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      # Setup .npmrc file to publish to npm
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.x"
+          registry-url: "https://registry.npmjs.org"
+      - run: corepack enable
+      - run: yarn
+      - run: yarn build
+      - run: yarn npm publish --access public
+        working-directory: packages/webrtc-client
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   publish-ts-client:
     runs-on: ubuntu-latest
     permissions:

--- a/packages/webrtc-client/package.json
+++ b/packages/webrtc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/webrtc-client",
-  "version": "0.10.2",
+  "version": "0.14.0",
   "description": "Typescript client library for ExWebRTC/WebRTC endpoint in Membrane RTC Engine",
   "license": "Apache-2.0",
   "author": "Fishjam Team",


### PR DESCRIPTION
## Description

The Webrtc package is useful for elixir community as a client for Membrane RTC endpoint.
 
## Motivation and Context

Some folks on discord asked for it.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
