### PR TITLE
Don't deploy fishjam chat as dependabotbot

### DIFF
--- a/.github/workflows/fishjam-chat.yaml
+++ b/.github/workflows/fishjam-chat.yaml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   build-deploy:
+    if: github.actor != 'dependabot[bot]'
     environment:
       name: fishjam-chat
       url: ${{ vars.FISHJAM_CHAT_URL }}


### PR DESCRIPTION
## Description

Stop deploying dependabot builds.

## Motivation and Context

They don't have secrets access.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
