### PR TITLE
Keep the devices disabled/muted state after changing device.

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/DeviceSettings.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DeviceSettings.tsx
@@ -1,18 +1,36 @@
 import { useCamera, useMicrophone } from "@fishjam-cloud/react-client";
+import { Mic, MicOff, Video, VideoOff } from "lucide-react";
 
 import AudioVisualizer from "./AudioVisualizer";
 import { BlurToggleButton } from "./BlurToggle";
 import { DeviceSelect } from "./DeviceSelect";
+import { ToggleButton } from "./ToggleButton";
 import VideoPlayer from "./VideoPlayer";
 
 export const CameraSettings = () => {
-  const { cameraStream, cameraDevices, selectCamera, activeCamera } =
-    useCamera();
+  const {
+    cameraStream,
+    cameraDevices,
+    selectCamera,
+    activeCamera,
+    toggleCamera,
+    isCameraOn,
+  } = useCamera();
 
   const hasValidDevices = cameraDevices.some((device) => device.deviceId);
 
+  const onCameraToggle = () => {
+    toggleCamera();
+  };
+
   return (
     <div className="flex flex-col items-center justify-center gap-4">
+      <ToggleButton
+        subject="camera"
+        onClick={onCameraToggle}
+        Icon={isCameraOn ? VideoOff : Video}
+        isOn={isCameraOn}
+      />
       <DeviceSelect
         devices={cameraDevices}
         onSelectDevice={selectCamera}
@@ -34,10 +52,19 @@ export const MicrophoneSettings = () => {
     microphoneDevices,
     selectMicrophone,
     activeMicrophone,
+    toggleMicrophone,
+    isMicrophoneOn,
   } = useMicrophone();
 
   return (
     <div className="flex flex-col items-center justify-center gap-4">
+      <ToggleButton
+        subject="camera"
+        onClick={toggleMicrophone}
+        Icon={isMicrophoneOn ? MicOff : Mic}
+        isOn={isMicrophoneOn}
+      />
+
       <DeviceSelect
         devices={microphoneDevices}
         defaultDevice={activeMicrophone ?? microphoneDevices[0]}

--- a/examples/react-client/fishjam-chat/src/components/DeviceSettings.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DeviceSettings.tsx
@@ -19,15 +19,11 @@ export const CameraSettings = () => {
 
   const hasValidDevices = cameraDevices.some((device) => device.deviceId);
 
-  const onCameraToggle = () => {
-    toggleCamera();
-  };
-
   return (
     <div className="flex flex-col items-center justify-center gap-4">
       <ToggleButton
         subject="camera"
-        onClick={onCameraToggle}
+        onClick={toggleCamera}
         Icon={isCameraOn ? VideoOff : Video}
         isOn={isCameraOn}
       />
@@ -59,7 +55,7 @@ export const MicrophoneSettings = () => {
   return (
     <div className="flex flex-col items-center justify-center gap-4">
       <ToggleButton
-        subject="camera"
+        subject="microphone"
         onClick={toggleMicrophone}
         Icon={isMicrophoneOn ? MicOff : Mic}
         isOn={isMicrophoneOn}

--- a/examples/react-client/fishjam-chat/src/components/ToggleButton.tsx
+++ b/examples/react-client/fishjam-chat/src/components/ToggleButton.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 
 import { cn } from "@/lib/utils";
 
-import { Button,type ButtonProps } from "./ui/button";
+import { Button, type ButtonProps } from "./ui/button";
 
 type Props = {
   isOn: boolean;

--- a/examples/react-client/fishjam-chat/src/components/ToggleButton.tsx
+++ b/examples/react-client/fishjam-chat/src/components/ToggleButton.tsx
@@ -1,0 +1,30 @@
+import type { LucideIcon } from "lucide-react";
+import type { FC } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Button,type ButtonProps } from "./ui/button";
+
+type Props = {
+  isOn: boolean;
+  Icon: LucideIcon;
+  subject: string;
+} & ButtonProps &
+  React.RefAttributes<HTMLButtonElement>;
+
+export const ToggleButton: FC<Props> = ({ isOn, Icon, subject, ...props }) => {
+  return (
+    <Button
+      {...props}
+      type="button"
+      variant={isOn ? "default" : "outline"}
+      className={cn("space-x-2", props.className)}
+    >
+      <Icon size={20} />
+
+      <span>
+        {isOn ? "Disable" : "Enable"} {subject}
+      </span>
+    </Button>
+  );
+};

--- a/packages/react-client/src/hooks/internal/devices/useDeviceManager.ts
+++ b/packages/react-client/src/hooks/internal/devices/useDeviceManager.ts
@@ -19,7 +19,7 @@ type DeviceManagerProps = {
 };
 
 export type DeviceManager = {
-  startDevice: (deviceId?: string) => Promise<[MediaStreamTrack, null] | [null, DeviceError]>;
+  startDevice: (deviceId?: string | null) => Promise<[MediaStreamTrack, null] | [null, DeviceError]>;
   stopDevice: () => void;
   selectDevice: (deviceId: string) => Promise<[MediaStreamTrack, null] | [null, DeviceError]> | undefined;
   activeDevice: DeviceItem | null;
@@ -57,7 +57,7 @@ function getStopStreamAction(deviceType: "audio" | "video"): SetStateAction<Medi
 async function getDeviceStream(
   type: "audio" | "video",
   constraints: MediaTrackConstraints | boolean | undefined,
-  deviceId?: string,
+  deviceId: string | null,
 ) {
   constraints = typeof constraints === "object" ? constraints : {};
   if (deviceId) {
@@ -80,7 +80,7 @@ export const useDeviceManager = ({
   deviceError,
   setDeviceError,
 }: DeviceManagerProps): DeviceManager => {
-  const selectedDeviceRef = useRef<string | undefined>(undefined);
+  const selectedDeviceRef = useRef<string | null>(null);
 
   const rawTrack = useMemo(() => mediaStream && getTrackFromStream(mediaStream, deviceType), [mediaStream, deviceType]);
 
@@ -119,7 +119,7 @@ export const useDeviceManager = ({
       try {
         const stream = await getDeviceStream(deviceType, constraints, deviceId);
 
-        selectedDeviceRef.current = undefined;
+        selectedDeviceRef.current = null;
 
         setMediaStream(getReplaceStreamAction(stream, deviceType));
 

--- a/packages/react-client/src/hooks/internal/useTrackManager.ts
+++ b/packages/react-client/src/hooks/internal/useTrackManager.ts
@@ -25,8 +25,16 @@ export const useTrackManager = ({
 }: TrackManagerConfig): TrackManager => {
   const currentTrackIdRef = useRef<string | null>(null);
 
-  const { startDevice, stopDevice, enableDevice, disableDevice, deviceTrack, applyMiddleware, currentMiddleware } =
-    deviceManager;
+  const {
+    startDevice,
+    stopDevice,
+    enableDevice,
+    disableDevice,
+    deviceTrack,
+    applyMiddleware,
+    currentMiddleware,
+    selectDevice: _selectDevice,
+  } = deviceManager;
 
   const getCurrentTrackId = useCallback(() => {
     const refTrackId = currentTrackIdRef.current;
@@ -36,8 +44,11 @@ export const useTrackManager = ({
   }, [tsClient]);
 
   const selectDevice = useCallback(
-    async (deviceId?: string) => {
-      const [newTrack, error] = await startDevice(deviceId);
+    async (deviceId: string) => {
+      const result = await _selectDevice(deviceId);
+      if (!result) return;
+
+      const [newTrack, error] = result;
       if (error) return error;
 
       const currentTrackId = getCurrentTrackId();
@@ -45,7 +56,7 @@ export const useTrackManager = ({
 
       await tsClient.replaceTrack(currentTrackId, newTrack);
     },
-    [getCurrentTrackId, startDevice, tsClient],
+    [getCurrentTrackId, _selectDevice, tsClient],
   );
 
   const setTrackMiddleware = useCallback(

--- a/packages/react-client/src/types/internal.ts
+++ b/packages/react-client/src/types/internal.ts
@@ -15,7 +15,7 @@ export type ScreenShareState = (
 ) & { tracksMiddleware?: TracksMiddleware | null };
 
 export interface TrackManager {
-  selectDevice: (deviceId?: string) => Promise<undefined | DeviceError>;
+  selectDevice: (deviceId: string) => Promise<undefined | DeviceError>;
   deviceTrack: MediaStreamTrack | null;
   currentMiddleware: TrackMiddleware;
   setTrackMiddleware: (middleware: TrackMiddleware | null) => Promise<void>;


### PR DESCRIPTION
## Description

Preserves the initial state of device being turned/muted on/off after changing a device.

## Motivation and Context

Current solution of the devices being always turned on during changing them is prone to user sending out data he possibly wouldn't like to.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
