### PR TITLE
Fix the `maxBandwidth` parameter 

### DIFF
--- a/packages/react-client/src/utils/track.ts
+++ b/packages/react-client/src/utils/track.ts
@@ -70,7 +70,9 @@ export const getConfigAndBandwidthFromProps = (
     disabledVariants: getDisabledEncodings(encodings),
   };
 
-  const variantEntries = Object.entries(bandwidthLimits.simulcast) as unknown as [Variant, number][];
+  const variantEntries = Object.entries(bandwidthLimits.simulcast).map(
+    ([key, value]) => [Number(key), value] as [Variant, number],
+  );
 
   const bandwidth = new Map<Variant, number>(variantEntries);
   return [bandwidth, config] as const;


### PR DESCRIPTION
## Description

Casts the Object.entries result back to a number.

## Motivation and Context

The `maxBandwidth` object was broken due to it's keys being silently cast to string.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
