### PR TITLE
FCE-1453 / Add current device property

### DIFF
--- a/examples/react-client/fishjam-chat/src/components/DeviceSettings.tsx
+++ b/examples/react-client/fishjam-chat/src/components/DeviceSettings.tsx
@@ -12,7 +12,7 @@ export const CameraSettings = () => {
     cameraStream,
     cameraDevices,
     selectCamera,
-    activeCamera,
+    currentCamera,
     toggleCamera,
     isCameraOn,
   } = useCamera();
@@ -30,7 +30,7 @@ export const CameraSettings = () => {
       <DeviceSelect
         devices={cameraDevices}
         onSelectDevice={selectCamera}
-        defaultDevice={activeCamera ?? cameraDevices[0]}
+        defaultDevice={currentCamera ?? cameraDevices[0]}
       />
 
       {hasValidDevices && <BlurToggleButton type="button" />}
@@ -47,7 +47,7 @@ export const MicrophoneSettings = () => {
     microphoneStream,
     microphoneDevices,
     selectMicrophone,
-    activeMicrophone,
+    currentMicrophone,
     toggleMicrophone,
     isMicrophoneOn,
   } = useMicrophone();
@@ -63,7 +63,7 @@ export const MicrophoneSettings = () => {
 
       <DeviceSelect
         devices={microphoneDevices}
-        defaultDevice={activeMicrophone ?? microphoneDevices[0]}
+        defaultDevice={currentMicrophone ?? microphoneDevices[0]}
         onSelectDevice={selectMicrophone}
       />
 

--- a/packages/react-client/src/hooks/devices/useCamera.ts
+++ b/packages/react-client/src/hooks/devices/useCamera.ts
@@ -28,6 +28,7 @@ export function useCamera() {
      */
     selectCamera: videoTrackManager.selectDevice,
     /**
+     * @deprecated Use `currentCamera` and `isCameraOn` instead
      * Indicates which camera is now turned on and streaming
      */
     activeCamera: cameraManager.activeDevice,

--- a/packages/react-client/src/hooks/devices/useCamera.ts
+++ b/packages/react-client/src/hooks/devices/useCamera.ts
@@ -32,7 +32,11 @@ export function useCamera() {
      */
     activeCamera: cameraManager.activeDevice,
     /**
-     * Indicates whether the microphone is streaming video
+     * Indicates which camera is now selected
+     */
+    currentCamera: cameraManager.selectedDevice,
+    /**
+     * Indicates whether the camera is streaming video
      */
     isCameraOn: !!cameraStream,
     /**

--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -26,6 +26,7 @@ export function useMicrophone() {
     /** Selects the microphone device */
     selectMicrophone: audioTrackManager.selectDevice,
     /**
+     * @deprecated Use `currentMicrophone` and `isMicrophoneOn` instead
      * Indicates which microphone is now turned on and streaming audio
      */
     activeMicrophone: microphoneManager.activeDevice,

--- a/packages/react-client/src/hooks/devices/useMicrophone.ts
+++ b/packages/react-client/src/hooks/devices/useMicrophone.ts
@@ -30,6 +30,10 @@ export function useMicrophone() {
      */
     activeMicrophone: microphoneManager.activeDevice,
     /**
+     * Indicates which microphone is now selected
+     */
+    currentMicrophone: microphoneManager.selectedDevice,
+    /**
      * Indicates whether the microphone is streaming audio
      */
     isMicrophoneOn: !!microphoneStream,


### PR DESCRIPTION
## Description

Introduces `selectedCamera` and `selectedMicrophone` properties.
Deprecates `activeCamera` and `activeMicrophone` properties.

## Motivation and Context

The "active device" property did not provide information about which device was selected when a device was off.
Right now, "selected device" shows the device that is being used or will be used after it is turned on. 
"Is device on" indicates if the device is turned on.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
