### PR TITLE
FCE-1353 / fix endless renegotiation state

### DIFF
--- a/packages/webrtc-client/src/webRTCEndpoint.ts
+++ b/packages/webrtc-client/src/webRTCEndpoint.ts
@@ -201,8 +201,6 @@ export class WebRTCEndpoint extends (EventEmitter as new () => TypedEmitter<Requ
 
       this.remote.addTracks(endpointId, trackIdToTrack);
     } else if (event.tracksRemoved) {
-      this.localTrackManager.ongoingRenegotiation = true;
-
       const { endpointId, trackIds } = event.tracksRemoved;
 
       if (this.getEndpointId() === endpointId) return;


### PR DESCRIPTION
## Description

Removes setting ongoing renegotiation flag after handling removed tracks.

## Motivation and Context

There is no actual renegotiation in that case.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
