### PR TITLE
Fix partial device initialization

### DIFF
--- a/packages/react-client/src/hooks/internal/devices/useMediaDevices.ts
+++ b/packages/react-client/src/hooks/internal/devices/useMediaDevices.ts
@@ -74,8 +74,8 @@ export const useMediaDevices = ({ videoConstraints, audioConstraints, persistHan
 
         const { stream, errors } = media;
 
-        const videoDeviceId = stream?.getVideoTracks()[0].getSettings().deviceId;
-        const audioDeviceId = stream?.getAudioTracks()[0].getSettings().deviceId;
+        const videoDeviceId = stream?.getVideoTracks()[0]?.getSettings().deviceId;
+        const audioDeviceId = stream?.getAudioTracks()[0]?.getSettings().deviceId;
 
         const videoDevice = fetchedDevices.find((device) => device.deviceId === videoDeviceId);
         const audioDevice = fetchedDevices.find((device) => device.deviceId === audioDeviceId);


### PR DESCRIPTION
## Description

Don't assume that `initializeDevices` will always result in receiving both audio and video tracks.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
