### PR TITLE
Initialize stream when only audio is sent

### DIFF
--- a/examples/react-client/livestreaming/src/components/ConnectForm.tsx
+++ b/examples/react-client/livestreaming/src/components/ConnectForm.tsx
@@ -39,11 +39,7 @@ export const ConnectForm = () => {
             <Input
               id="fishjam-id"
               required
-              {...form.register("fishjamId", {
-                validate: (value) =>
-                  value.length === 32 ||
-                  "Fishjam ID must be 32 characters long",
-              })}
+              {...form.register("fishjamId")}
               placeholder="Your Fishjam ID"
               disabled={isLocked}
             />

--- a/packages/ts-client/src/livestream.ts
+++ b/packages/ts-client/src/livestream.ts
@@ -32,17 +32,15 @@ export function receiveLivestream(url: string, token?: string, callbacks?: Lives
 
   return new Promise<ReceiveLivestreamResult>((resolve, reject) => {
     pc.ontrack = (event) => {
-      if (event.track.kind == 'video' || event.track.kind == 'audio') {
-        const stream = event.streams[0];
-        if (stream) {
-          resolve({
-            stream,
-            stop: async () => {
-              await whep.stop();
-              callbacks?.onConnectionStateChange?.(pc);
-            },
-          });
-        }
+      const stream = event.streams[0];
+      if (stream) {
+        resolve({
+          stream,
+          stop: async () => {
+            await whep.stop();
+            callbacks?.onConnectionStateChange?.(pc);
+          },
+        });
       }
     };
 

--- a/packages/ts-client/src/livestream.ts
+++ b/packages/ts-client/src/livestream.ts
@@ -32,7 +32,7 @@ export function receiveLivestream(url: string, token?: string, callbacks?: Lives
 
   return new Promise<ReceiveLivestreamResult>((resolve, reject) => {
     pc.ontrack = (event) => {
-      if (event.track.kind == 'video') {
+      if (event.track.kind == 'video' || event.track.kind == 'audio') {
         const stream = event.streams[0];
         if (stream) {
           resolve({


### PR DESCRIPTION
## Description

Handles audio-only stream initialization. 

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
