### PR TITLE
Fix local VAD flickering on cleanup

### DIFF
--- a/packages/react-client/src/hooks/useLocalVAD.ts
+++ b/packages/react-client/src/hooks/useLocalVAD.ts
@@ -38,10 +38,16 @@ export const useLocalVAD = (options: { disabled: boolean }): Record<PeerId, bool
     if (options.disabled || !localPeerId || !microphoneTrackId) return;
 
     let silenceTicks = 0;
-    let timeoutId: ReturnType<typeof setTimeout>;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+    const controller = new AbortController();
+    const { signal } = controller;
 
     const poll = async () => {
+      if (signal.aborted) return;
+
       const trackAudio = await fishjamClient?.current?.getLocalTrackAudioLevel(microphoneTrackId);
+      if (signal.aborted) return;
+
       if (trackAudio != null && trackAudio.level > THRESHOLD) {
         silenceTicks = 0;
         setIsSpeaking(true);
@@ -52,12 +58,14 @@ export const useLocalVAD = (options: { disabled: boolean }): Record<PeerId, bool
         }
       }
 
+      if (signal.aborted) return;
       timeoutId = setTimeout(poll, 100);
     };
 
     timeoutId = setTimeout(poll, 0);
 
     return () => {
+      controller.abort();
       clearTimeout(timeoutId);
       setIsSpeaking(false);
     };


### PR DESCRIPTION
## Description                                                                                                                                                                                                 
                                                                                                                   
  `useLocalVAD` polls `getLocalTrackAudioLevel` in a `setTimeout` loop. On cleanup it calls `clearTimeout`, but that can't cancel a poll that's already mid-`await`. The in-flight promise still resolves after
  cleanup runs, calls `setIsSpeaking`, and schedules a fresh `setTimeout` so `isSpeaking` flickers and the poll loop leaks past the disabled state.                                                            
                                                                                                                                                     
  Fix: added an `AbortController` and check `signal.aborted` around each `await` boundary. The poll exits cleanly on cleanup and won't schedule another timeout.                                                 
                                                                                                                                                                                                                 
  ## Motivation and Context
                                                                                                                                                                                                                 
  `isSpeaking` was flickering when the hook got toggled off or the component unmounted, and a stale poll could keep running against aborted state. Users saw the speaking indicator flash briefly after going
  silent or leaving the room.                                                                                                                                                                                    
                             
  ## Documentation impact                                                                                                                                                                                        
                                                                                                                   
  - [ ] Documentation update required
  - [ ] Documentation updated [in another PR](_)
  - [x] No documentation update required        
                                        
  ## Types of changes
                     
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [ ] New feature (non-breaking change which adds functionality)                                                                                                                                               
  - [ ] Breaking change (fix or feature that would cause existing functionality to
        not work as expected)   