### PR TITLE
FCE-3229 add general set received track quality method

### DIFF
--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -119,8 +119,9 @@ export function usePeers<PeerMetadata = Record<string, unknown>, ServerMetadata 
       ),
   );
 
-  const setReceivedTrackQuality = useCallback(
-    (trackId: string, quality: Variant) => fishjamClient.current.setTargetTrackEncoding(trackId, quality),
+  const setReceivedTracksQuality = useCallback(
+    (trackIds: string[], quality: Variant) =>
+      trackIds.forEach((trackId) => fishjamClient.current.setTargetTrackEncoding(trackId, quality)),
     [fishjamClient],
   );
 
@@ -139,10 +140,10 @@ export function usePeers<PeerMetadata = Record<string, unknown>, ServerMetadata 
      */
     peers: remotePeers,
     /**
-     * This function allows to set the quality of a track received from a remote peer.
-     * @param trackId The id of the track to set the quality for.
+     * This function allows to set the quality of tracks received from remote peers.
+     * @param trackIds The array of the track ids to set the quality for.
      * @param quality The quality to set for the track.
      */
-    setReceivedTrackQuality,
+    setReceivedTracksQuality,
   };
 }

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,5 +1,5 @@
 import type { FishjamClient, Metadata, Peer, SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-client";
-import { useContext } from "react";
+import { useCallback, useContext } from "react";
 
 import { FishjamClientContext } from "../contexts/fishjamClient";
 import { FishjamClientStateContext } from "../contexts/fishjamState";
@@ -119,6 +119,11 @@ export function usePeers<PeerMetadata = Record<string, unknown>, ServerMetadata 
       ),
   );
 
+  const setReceivedTrackQuality = useCallback(
+    (trackId: string, quality: Variant) => fishjamClient.current.setTargetTrackEncoding(trackId, quality),
+    [fishjamClient],
+  );
+
   return {
     /**
      * The local peer with distinguished tracks (camera, microphone, screen share).
@@ -133,5 +138,11 @@ export function usePeers<PeerMetadata = Record<string, unknown>, ServerMetadata 
      * This property will be removed in future versions.
      */
     peers: remotePeers,
+    /**
+     * This function allows to set the quality of a track received from a remote peer.
+     * @param trackId The id of the track to set the quality for.
+     * @param quality The quality to set for the track.
+     */
+    setReceivedTrackQuality,
   };
 }


### PR DESCRIPTION
## Description

Adds a general `setReceivedTracksQuality` method to `usePeers` hook.

## Motivation and Context

The `track.setReceivedQuality` method usage gets tricky if you want to use it in `useEffect`. 
Adding a general method resolves this by separating the function from the state.

## Documentation impact

- [x] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
