### PR TITLE
[FCE-3270] fix(ts-client): serialize receiveMediaEvent calls

### DIFF
--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -96,6 +96,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
 
   private reconnectManager: ReconnectManager<PeerMetadata, ServerMetadata>;
   private peerMessageQueue: MessageQueue;
+  private receiveMediaEventChain: Promise<void> = Promise.resolve();
 
   private sendStatisticsInterval: NodeJS.Timeout | undefined = undefined;
 
@@ -230,7 +231,12 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
         } else if (data.authRequest) {
           this.logger.warn('Received unexpected control message: authRequest');
         } else if (serverMediaEvent) {
-          this.webrtc?.receiveMediaEvent(ServerMediaEvent.encode(serverMediaEvent).finish());
+          const encoded = ServerMediaEvent.encode(serverMediaEvent).finish();
+          this.receiveMediaEventChain = this.receiveMediaEventChain
+            .catch((e) => {
+              this.logger.warn(`receiveMediaEvent failed: ${e}`);
+            })
+            .finally(() => this.webrtc?.receiveMediaEvent(encoded));
         }
       } catch (e) {
         this.logger.warn(`Received invalid control message, error: ${e}`);
@@ -977,6 +983,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     }
     this.websocket = null;
     this.webrtc = null;
+    this.receiveMediaEventChain = Promise.resolve();
     this.cameraStream = new MediaStream();
     this.screenShareStream = new MediaStream();
     this.trackIdToTrack.clear();

--- a/packages/ts-client/src/FishjamClient.ts
+++ b/packages/ts-client/src/FishjamClient.ts
@@ -231,12 +231,12 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
         } else if (data.authRequest) {
           this.logger.warn('Received unexpected control message: authRequest');
         } else if (serverMediaEvent) {
-          const encoded = ServerMediaEvent.encode(serverMediaEvent).finish();
+          const encodedEvent = ServerMediaEvent.encode(serverMediaEvent).finish();
           this.receiveMediaEventChain = this.receiveMediaEventChain
             .catch((e) => {
               this.logger.warn(`receiveMediaEvent failed: ${e}`);
             })
-            .finally(() => this.webrtc?.receiveMediaEvent(encoded));
+            .finally(() => this.webrtc?.receiveMediaEvent(encodedEvent));
         }
       } catch (e) {
         this.logger.warn(`Received invalid control message, error: ${e}`);


### PR DESCRIPTION
## Description                                                                                                                                                                                           
                                                                                                                    
  Serialize `receiveMediaEvent` calls in `FishjamClient` by chaining them through a single promise (`receiveMediaEventChain`). Each incoming server media event waits for the previous one to settle before
   being passed to `webrtc.receiveMediaEvent`. The chain is reset on disconnect.
                                                                                                                                                                                                           
  ## Motivation and Context                                                                                         

  Server media events were dispatched to the WebRTC layer the moment they arrived, with no ordering guarantee between handlers. When `receiveMediaEvent` did asynchronous work, concurrent events could    
  interleave and produce out-of-order state updates. Chaining ensures events are applied in the order they were received.
                                                                                                                                                                                                           
  ## Documentation impact                                                                                           

  - [ ] Documentation update required
  - [ ] Documentation updated [in another PR](_)
  - [x] No documentation update required

  ## Types of changes                                                                                                                                                                                      
   
  - [x] Bug fix (non-breaking change which fixes an issue)                                                                                                                                                 
  - [ ] New feature (non-breaking change which adds functionality)                                                  
  - [ ] Breaking change (fix or feature that would cause existing functionality to
        not work as expected)     