### PR TITLE
FCE-3295: Fix media event queue order catch

### DIFF
--- a/packages/webrtc-client/src/webRTCEndpoint.ts
+++ b/packages/webrtc-client/src/webRTCEndpoint.ts
@@ -160,8 +160,8 @@ export class WebRTCEndpoint extends (EventEmitter as new () => TypedEmitter<Requ
   public receiveMediaEvent = (mediaEvent: SerializedMediaEvent): Promise<void> => {
     const deserializedMediaEvent = deserializeServerMediaEvent(mediaEvent);
 
-    const next = this.mediaEventQueue.then(() => this.handleMediaEvent(deserializedMediaEvent));
-    this.mediaEventQueue = next.catch(() => undefined);
+    const next = this.mediaEventQueue.catch(() => undefined).then(() => this.handleMediaEvent(deserializedMediaEvent));
+    this.mediaEventQueue = next;
     return next;
   };
 


### PR DESCRIPTION
## Description

- `webRTCEndpoint.ts`: chain `.catch()` before `.then()` on `mediaEventQueue` so a rejected prior event doesn't propagate the same rejection to every subsequent `receiveMediaEvent` caller.

## Motivation and Context

Previous order assigned the caught queue back to `mediaEventQueue` but returned the uncaught `next`, so one failed handler would reject every queued event after it. Catching first keeps the queue alive and isolates failures to their own caller.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
