### PR TITLE
invert track manager order

### DIFF
--- a/packages/mobile-client/package.json
+++ b/packages/mobile-client/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "peerDependencies": {
-    "@fishjam-cloud/react-native-webrtc": "0.26.0",
+    "@fishjam-cloud/react-native-webrtc": "0.26.2",
     "expo": "*",
     "react": "*",
     "react-native": "*",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fishjam-cloud/react-client": "workspace:*",
-    "@fishjam-cloud/react-native-webrtc": "0.26.0",
+    "@fishjam-cloud/react-native-webrtc": "0.26.2",
     "fast-text-encoding": "1.0.6",
     "react-native-get-random-values": "1.11.0",
     "react-native-url-polyfill": "3.0.0"

--- a/packages/react-client/src/FishjamProvider.tsx
+++ b/packages/react-client/src/FishjamProvider.tsx
@@ -100,16 +100,6 @@ export function FishjamProvider(props: FishjamProviderProps) {
     [props.bandwidthLimits],
   );
 
-  const videoTrackManager = useTrackManager({
-    tsClient: fishjamClientRef.current,
-    peerStatus,
-    deviceManager: cameraManager,
-    bandwidthLimits: mergedBandwidthLimits,
-    streamConfig: props.videoConfig,
-    type: "camera",
-    logger,
-  });
-
   const audioTrackManager = useTrackManager({
     tsClient: fishjamClientRef.current,
     peerStatus,
@@ -117,6 +107,16 @@ export function FishjamProvider(props: FishjamProviderProps) {
     bandwidthLimits: mergedBandwidthLimits,
     streamConfig: props.audioConfig,
     type: "microphone",
+    logger,
+  });
+
+  const videoTrackManager = useTrackManager({
+    tsClient: fishjamClientRef.current,
+    peerStatus,
+    deviceManager: cameraManager,
+    bandwidthLimits: mergedBandwidthLimits,
+    streamConfig: props.videoConfig,
+    type: "camera",
     logger,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
   resolution: "@fishjam-cloud/react-native-client@workspace:packages/mobile-client"
   dependencies:
     "@fishjam-cloud/react-client": "workspace:*"
-    "@fishjam-cloud/react-native-webrtc": "npm:0.26.0"
+    "@fishjam-cloud/react-native-webrtc": "npm:0.26.2"
     eslint-config-expo: "npm:~9.2.0"
     eslint-import-resolver-typescript: "npm:^3.10.1"
     eslint-plugin-prettier: "npm:^5.5.1"
@@ -3407,7 +3407,7 @@ __metadata:
     react-native-url-polyfill: "npm:3.0.0"
     typescript: "npm:^5.8.3"
   peerDependencies:
-    "@fishjam-cloud/react-native-webrtc": 0.26.0
+    "@fishjam-cloud/react-native-webrtc": 0.26.2
     expo: "*"
     react: "*"
     react-native: "*"
@@ -3415,15 +3415,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fishjam-cloud/react-native-webrtc@npm:0.26.0":
-  version: 0.26.0
-  resolution: "@fishjam-cloud/react-native-webrtc@npm:0.26.0"
+"@fishjam-cloud/react-native-webrtc@npm:0.26.2":
+  version: 0.26.2
+  resolution: "@fishjam-cloud/react-native-webrtc@npm:0.26.2"
   dependencies:
     base64-js: "npm:1.5.1"
     debug: "npm:4.3.4"
   peerDependencies:
     react-native: "*"
-  checksum: 10c0/392370fa8f477df81b3eaf12ae39d28000fd17b79784d18bba49d07314ae62546efa3f634f215514c77c55efd5f244aaa3a94fb7e08579f81d552db418cd1e03
+  checksum: 10c0/7dc36b2dd356362a14e4c348a5dc2f0b0f163cc962c3ad7e0d5db7d0e2233417d33aaf44ad78bcfdec550117f834bbb2644efc9b0a01a58381b95fa2f3f35f25
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Swap order in `FishjamProvider` so `audioTrackManager` initializes before `videoTrackManager`
- Bump `@fishjam-cloud/react-native-webrtc` to `0.26.2` in `mobile-client`

## Motivation and Context

Audio track must register first to fix track manager ordering (FCE-3304).

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)