### PR TITLE
FCE-3321 throw missing sandbox url error when calling methods

### DIFF
--- a/packages/react-client/src/hooks/useSandbox.ts
+++ b/packages/react-client/src/hooks/useSandbox.ts
@@ -1,5 +1,7 @@
 import { useCallback } from "react";
 
+import { MissingSandboxApiUrlError } from "../utils/errors";
+
 type BasicInfo = { id: string; name: string };
 type RoomManagerResponse = {
   peerToken: string;
@@ -15,14 +17,12 @@ export type UseSandboxProps = {
 export type RoomType = "conference" | "livestream" | "audio_only";
 
 export const useSandbox = (props: UseSandboxProps) => {
-  const sandboxApiUrl = props?.sandboxApiUrl;
-
-  if (!sandboxApiUrl) {
-    throw new Error("useSandbox requires a sandboxApiUrl, you can get it at: https://fishjam.io/app/sandbox");
-  }
+  const sandboxApiUrl = props.sandboxApiUrl;
 
   const getSandboxPeerToken = useCallback(
     async (roomName: string, peerName: string, roomType: RoomType = "conference") => {
+      if (!sandboxApiUrl) throw new MissingSandboxApiUrlError();
+
       const url = new URL(sandboxApiUrl);
       url.searchParams.set("roomName", roomName);
       url.searchParams.set("peerName", peerName);
@@ -43,6 +43,8 @@ export const useSandbox = (props: UseSandboxProps) => {
 
   const getSandboxViewerToken = useCallback(
     async (roomName: string) => {
+      if (!sandboxApiUrl) throw new MissingSandboxApiUrlError();
+
       const url = new URL(`${sandboxApiUrl}/${roomName}/livestream-viewer-token`);
 
       const res = await fetch(url);
@@ -62,6 +64,8 @@ export const useSandbox = (props: UseSandboxProps) => {
 
   const getSandboxLivestream = useCallback(
     async (roomName: string, isPublic: boolean = false) => {
+      if (!sandboxApiUrl) throw new MissingSandboxApiUrlError();
+
       const url = new URL(`${sandboxApiUrl}/livestream`);
       url.searchParams.set("roomName", roomName);
       url.searchParams.set("public", isPublic.toString());

--- a/packages/react-client/src/utils/errors.ts
+++ b/packages/react-client/src/utils/errors.ts
@@ -23,3 +23,10 @@ export const parseUserMediaError = (error: unknown, logger: ReturnType<typeof ge
       return UNHANDLED_ERROR;
   }
 };
+
+export class MissingSandboxApiUrlError extends Error {
+  constructor() {
+    super("useSandbox requires a sandboxApiUrl, you can get it at: https://fishjam.io/app/sandbox");
+    this.name = "MissingSandboxApiUrlError";
+  }
+}


### PR DESCRIPTION
## Description

Moves the no sandbox url error to the moment user calls the backend.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
