### PR TITLE
make useSandbox tolerate undefined props

### DIFF
--- a/packages/react-client/src/hooks/useSandbox.ts
+++ b/packages/react-client/src/hooks/useSandbox.ts
@@ -17,7 +17,7 @@ export type UseSandboxProps = {
 export type RoomType = "conference" | "livestream" | "audio_only";
 
 export const useSandbox = (props: UseSandboxProps) => {
-  const sandboxApiUrl = props.sandboxApiUrl;
+  const sandboxApiUrl = props?.sandboxApiUrl;
 
   const getSandboxPeerToken = useCallback(
     async (roomName: string, peerName: string, roomType: RoomType = "conference") => {


### PR DESCRIPTION
`useSandbox()` now raises a TypeError, we can avoid that and raise the MissingSandboxApiUrlError later