### PR TITLE
FCE-3301: Bump react-native-webrtc version

### DIFF
--- a/packages/mobile-client/package.json
+++ b/packages/mobile-client/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "peerDependencies": {
-    "@fishjam-cloud/react-native-webrtc": "0.26.2",
+    "@fishjam-cloud/react-native-webrtc": "0.27.0",
     "expo": "*",
     "react": "*",
     "react-native": "*",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@fishjam-cloud/react-client": "workspace:*",
-    "@fishjam-cloud/react-native-webrtc": "0.26.2",
+    "@fishjam-cloud/react-native-webrtc": "0.27.0",
     "fast-text-encoding": "1.0.6",
     "react-native-get-random-values": "1.11.0",
     "react-native-url-polyfill": "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3397,7 +3397,7 @@ __metadata:
   resolution: "@fishjam-cloud/react-native-client@workspace:packages/mobile-client"
   dependencies:
     "@fishjam-cloud/react-client": "workspace:*"
-    "@fishjam-cloud/react-native-webrtc": "npm:0.26.2"
+    "@fishjam-cloud/react-native-webrtc": "npm:0.27.0"
     eslint-config-expo: "npm:~9.2.0"
     eslint-import-resolver-typescript: "npm:^3.10.1"
     eslint-plugin-prettier: "npm:^5.5.1"
@@ -3407,7 +3407,7 @@ __metadata:
     react-native-url-polyfill: "npm:3.0.0"
     typescript: "npm:^5.8.3"
   peerDependencies:
-    "@fishjam-cloud/react-native-webrtc": 0.26.2
+    "@fishjam-cloud/react-native-webrtc": 0.27.0
     expo: "*"
     react: "*"
     react-native: "*"
@@ -3415,15 +3415,15 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@fishjam-cloud/react-native-webrtc@npm:0.26.2":
-  version: 0.26.2
-  resolution: "@fishjam-cloud/react-native-webrtc@npm:0.26.2"
+"@fishjam-cloud/react-native-webrtc@npm:0.27.0":
+  version: 0.27.0
+  resolution: "@fishjam-cloud/react-native-webrtc@npm:0.27.0"
   dependencies:
     base64-js: "npm:1.5.1"
     debug: "npm:4.3.4"
   peerDependencies:
     react-native: "*"
-  checksum: 10c0/7dc36b2dd356362a14e4c348a5dc2f0b0f163cc962c3ad7e0d5db7d0e2233417d33aaf44ad78bcfdec550117f834bbb2644efc9b0a01a58381b95fa2f3f35f25
+  checksum: 10c0/ab8ec5ad5156c53c776e84fc44eebabd47e6fb8b592f591dcdb79e9b3753ba36ea9c7340e5b1aa5a03bcb4f6a9234ef5dbc53a2ee393c705350572092fa87597
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

- Bump `@fishjam-cloud/react-native-webrtc` from 0.26.2 to 0.27.0 in `packages/mobile-client` 

## Motivation and Context

Keep the mobile client on the latest `react-native-webrtc` release.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)