### PR TITLE
FCE-3336: Emit error if react-native-get-random-values is missing

### DIFF
--- a/packages/mobile-client/src/webrtc-polyfill.ts
+++ b/packages/mobile-client/src/webrtc-polyfill.ts
@@ -48,6 +48,8 @@ const assertGetRandomValuesPolyfill = () => {
   }
 };
 
+if (__DEV__) {
+  assertReactNativeWebRTCNativeModule();
+  assertGetRandomValuesPolyfill();
+}
 registerGlobalsPolyfill();
-assertReactNativeWebRTCNativeModule();
-assertGetRandomValuesPolyfill();

--- a/packages/mobile-client/src/webrtc-polyfill.ts
+++ b/packages/mobile-client/src/webrtc-polyfill.ts
@@ -3,6 +3,7 @@ import 'react-native-get-random-values';
 import 'react-native-url-polyfill/auto';
 
 import { EventTarget, registerGlobals } from '@fishjam-cloud/react-native-webrtc';
+import { NativeModules } from 'react-native';
 
 import { patchGetUserMediaWithPermissionWarnings } from './overrides/getUserMedia';
 import { RTCPeerConnection } from './overrides/RTCPeerConnection';
@@ -17,4 +18,36 @@ const registerGlobalsPolyfill = () => {
   patchGetUserMediaWithPermissionWarnings();
 };
 
+const assertReactNativeWebRTCNativeModule = () => {
+  if (NativeModules.WebRTCModule) return;
+  throw new Error(
+    '@fishjam-cloud/react-native-client: the native module for `@fishjam-cloud/react-native-webrtc` is not linked. ' +
+      'Install the package and rebuild your native app:\n' +
+      '  1. yarn add @fishjam-cloud/react-native-webrtc\n' +
+      '  2. cd ios && pod install (bare React Native)\n' +
+      '     or: npx expo prebuild --clean && rebuild your dev client (Expo)',
+  );
+};
+
+const assertGetRandomValuesPolyfill = () => {
+  try {
+    if (typeof globalThis.crypto?.getRandomValues !== 'function') {
+      throw new Error('crypto.getRandomValues is undefined');
+    }
+    globalThis.crypto.getRandomValues(new Uint8Array(1));
+  } catch (cause) {
+    const causeMessage = cause instanceof Error ? cause.message : String(cause);
+    throw new Error(
+      '@fishjam-cloud/react-native-client: `react-native-get-random-values` is not installed or its native module is not linked. ' +
+        'Install the package and rebuild your native app:\n' +
+        '  1. yarn add react-native-get-random-values\n' +
+        '  2. cd ios && pod install (bare React Native)\n' +
+        '     or: npx expo prebuild --clean && rebuild your dev client (Expo)\n' +
+        `Underlying error: ${causeMessage}`,
+    );
+  }
+};
+
 registerGlobalsPolyfill();
+assertReactNativeWebRTCNativeModule();
+assertGetRandomValuesPolyfill();


### PR DESCRIPTION
## Description

- Add `assertReactNativeWebrtcNativeModule` check that verifies `NativeModules.WebRTCModule` is linked and throws an actionable error with install/rebuild steps when missing.
- Add `assertGetRandomValuesPolyfill` check that verifies `globalThis.crypto.getRandomValues` works and throws an actionable error pointing to `react-native-get-random-values` when missing.
- Run both assertions after `registerGlobalsPolyfill()` in `packages/mobile-client/src/webrtc-polyfill.ts`.

## Motivation and Context

Surface a clear, actionable error at startup when required native dependencies are missing or not linked, instead of letting the SDK fail later with cryptic runtime errors.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)