### PR TITLE
FCE-3471 add sandbox moq methods

### DIFF
--- a/packages/react-client/src/hooks/useSandbox.ts
+++ b/packages/react-client/src/hooks/useSandbox.ts
@@ -79,5 +79,34 @@ export const useSandbox = (props: UseSandboxProps) => {
     [sandboxApiUrl],
   );
 
-  return { getSandboxPeerToken, getSandboxViewerToken, getSandboxLivestream };
+  const fetchMoqToken = useCallback(
+    async (streamName: string, type: "subscriber" | "publisher") => {
+      if (!sandboxApiUrl) throw new MissingSandboxApiUrlError();
+
+      const res = await fetch(`${sandboxApiUrl}/moq/${streamName}/${type}`);
+      if (!res.ok) throw new Error(`Failed to retrieve MoQ ${type} token for stream '${streamName}'.`);
+
+      const data: { token: string } = await res.json();
+      return data.token;
+    },
+    [sandboxApiUrl],
+  );
+
+  const getSandboxMoqPublisherToken = useCallback(
+    async (streamName: string) => fetchMoqToken(streamName, "publisher"),
+    [fetchMoqToken],
+  );
+
+  const getSandboxMoqSubscriberToken = useCallback(
+    async (streamName: string) => fetchMoqToken(streamName, "subscriber"),
+    [fetchMoqToken],
+  );
+
+  return {
+    getSandboxPeerToken,
+    getSandboxViewerToken,
+    getSandboxLivestream,
+    getSandboxMoqPublisherToken,
+    getSandboxMoqSubscriberToken,
+  };
 };

--- a/packages/react-client/src/hooks/useSandbox.ts
+++ b/packages/react-client/src/hooks/useSandbox.ts
@@ -83,7 +83,9 @@ export const useSandbox = (props: UseSandboxProps) => {
     async (streamName: string, type: "subscriber" | "publisher") => {
       if (!sandboxApiUrl) throw new MissingSandboxApiUrlError();
 
-      const res = await fetch(`${sandboxApiUrl}/moq/${streamName}/${type}`);
+      const urlEncodedStreamName = encodeURIComponent(streamName);
+
+      const res = await fetch(`${sandboxApiUrl}/moq/${urlEncodedStreamName}/${type}`);
       if (!res.ok) throw new Error(`Failed to retrieve MoQ ${type} token for stream '${streamName}'.`);
 
       const data: { token: string } = await res.json();


### PR DESCRIPTION
## Description

Adds sandbox api MoQ methods to the `useSandbox` hook.


## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
