### PR TITLE
Export encoding+reason in RemoteTrack

### DIFF
--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,4 +1,12 @@
-import type { EncodingReason, FishjamClient, Metadata, Peer, SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-client";
+import type {
+  EncodingReason,
+  FishjamClient,
+  Metadata,
+  Peer,
+  SimulcastConfig,
+  TrackMetadata,
+  Variant,
+} from "@fishjam-cloud/ts-client";
 import { useCallback, useContext } from "react";
 
 import { FishjamClientContext } from "../contexts/fishjamClient";

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,4 +1,4 @@
-import type { FishjamClient, Metadata, Peer, SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-client";
+import type { EncodingReason, FishjamClient, Metadata, Peer, SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-client";
 import { useCallback, useContext } from "react";
 
 import { FishjamClientContext } from "../contexts/fishjamClient";
@@ -46,11 +46,15 @@ function trackContextToRemoteTrack(
     stream: MediaStream | null;
     simulcastConfig?: SimulcastConfig | null;
     track: MediaStreamTrack | null;
+    encoding?: Variant;
+    encodingReason?: EncodingReason;
   },
   fishjamClient: FishjamClient,
 ): RemoteTrack {
   return {
     ...trackContextToTrack(track),
+    encoding: track.encoding,
+    encodingReason: track.encodingReason,
     setReceivedQuality: (encoding: Variant) => {
       fishjamClient.setTargetTrackEncoding(track.trackId, encoding);
     },

--- a/packages/react-client/src/types/public.ts
+++ b/packages/react-client/src/types/public.ts
@@ -1,6 +1,7 @@
 import type {
   DataCallback,
   DataChannelOptions,
+  EncodingReason,
   SimulcastConfig,
   TrackMetadata,
   Variant,
@@ -26,6 +27,8 @@ export type Track = {
 };
 
 export type RemoteTrack = Track & {
+  encoding?: Variant;
+  encodingReason?: EncodingReason;
   setReceivedQuality: (quality: Variant) => void;
 };
 


### PR DESCRIPTION
## Description

Add `encoding` and `encodingReason` fields to `RemoteTrack`

## Motivation and Context

Display currently active layer
FCE-2939

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
