### PR TITLE
fix: fetch submodule tags before checking webrtc release tag

### DIFF
--- a/release-automation/check-webrtc-published.mjs
+++ b/release-automation/check-webrtc-published.mjs
@@ -27,6 +27,15 @@ try {
   );
 }
 
+// CI checkout omits submodule tags, so fetch them before describe.
+try {
+  execSync(`git -C "${submoduleDir}" fetch --tags --quiet`, {
+    stdio: ["ignore", "ignore", "ignore"],
+  });
+} catch {
+  // best effort: tags may already be present locally
+}
+
 let tagAtHead;
 try {
   tagAtHead = execSync(


### PR DESCRIPTION

## Motivation and Context

```
check:webrtc-published fails on CI but passes locally

  check-webrtc-published.mjs runs git -C packages/react-native-webrtc describe --exact-match --tags HEAD. That only works if the submodule's tags are present in .git.

  - Locally it passes because the dev has previously fetched the submodule's tags.
  - On GH Actions actions/checkout@v4 with submodules: recursive checks out the submodule at the pinned SHA but does not fetch its tags, so git describe finds nothing → "Submodule HEAD (6b994c0) is not at a tagged release".
```

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
