### PR TITLE
docs: add AGENTS.md with Cursor Cloud specific setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# web-client-sdk
+
+Fishjam web/client SDK — a Yarn (Berry, v4) workspace monorepo.
+
+## Cursor Cloud specific instructions
+
+Non-obvious setup caveat:
+
+- `packages/protobufs/protos` and `packages/react-native-webrtc` are git submodules. They must be initialized before `yarn install`, otherwise install fails during resolution with `Workspace not found (@fishjam-cloud/react-native-webrtc@workspace:*)`. Run `git submodule update --init --recursive` first (the startup script does this).
+- Validated commands: `yarn build`, `yarn test:unit`, and `yarn lint:check` all pass. `yarn test:e2e` needs Playwright browsers and a running backend.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds an `AGENTS.md` with a `## Cursor Cloud specific instructions` section documenting a non-obvious setup caveat for this Yarn Berry workspace monorepo. No production code changes.

Discovered while setting up the dev environment (build, unit tests, and lint all pass):
- `packages/protobufs/protos` and `packages/react-native-webrtc` are git submodules and must be initialized (`git submodule update --init --recursive`) before `yarn install`, otherwise install fails with `Workspace not found (@fishjam-cloud/react-native-webrtc@workspace:*)`.
- Validated commands: `yarn build`, `yarn test:unit`, `yarn lint:check`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0d2d55e2-cb0f-49b0-8d5f-15c80c2982c8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

