### PR TITLE
FCE-3612: Add useCustomAudioSource hook

### DIFF
--- a/packages/mobile-client/src/hooks/useCustomAudioSource.ts
+++ b/packages/mobile-client/src/hooks/useCustomAudioSource.ts
@@ -1,0 +1,207 @@
+import {
+  createCustomAudioTrack,
+  type CustomAudioTrackResult,
+  type MediaStream,
+  pushAudioSamples as pushAudioSamplesToTrack,
+} from '@fishjam-cloud/react-native-webrtc';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useCustomSource } from '../overrides/hooks';
+
+const DEFAULT_SOURCE_ID = 'customAudioSource';
+const DEFAULT_SAMPLE_RATE_HZ = 48000;
+const DEFAULT_CHANNEL_COUNT = 1;
+
+/**
+ * Settings for {@link useCustomAudioSource}, fixed for the lifetime of a
+ * streaming session (a `startStreaming`/`stopStreaming` pair).
+ */
+export interface UseCustomAudioSourceOptions {
+  /**
+   * Stable id identifying this custom source. Defaults to
+   * `"customAudioSource"`.
+   */
+  sourceId?: string;
+  /**
+   * Sample rate of the PCM you will push, in hertz. Push whatever your source
+   * produces natively — it is resampled downstream. Defaults to `48000`.
+   */
+  sampleRateHz?: number;
+  /**
+   * `1` for mono or `2` for interleaved stereo. Defaults to `1`.
+   */
+  channelCount?: 1 | 2;
+}
+
+export interface UseCustomAudioSourceResult {
+  /** Whether the custom audio track is currently published. */
+  isStreaming: boolean;
+  /**
+   * Create the custom audio track and publish it. Once this resolves, pushed
+   * samples are streamed to the room. No-op when already streaming.
+   */
+  startStreaming: () => Promise<void>;
+  /**
+   * Unpublish and release the custom audio track. No-op when not streaming.
+   */
+  stopStreaming: () => Promise<void>;
+  /**
+   * Hand PCM to the published track. Call whenever your source produces
+   * audio, with any chunk size — the track re-paces it into a continuous
+   * stream, filling gaps with silence like a live microphone. `Float32Array`
+   * samples are expected in `[-1, 1]`; `Int16Array` is taken as-is. Safe to
+   * call anytime: samples pushed while not streaming are dropped.
+   */
+  pushAudioSamples: (samples: Float32Array | Int16Array) => void;
+  /** The error that failed the last `startStreaming` or `stopStreaming` call, if any. */
+  error: Error | null;
+}
+
+type StreamingSession = {
+  created: CustomAudioTrackResult | null;
+  cancelled: boolean;
+};
+
+function stopStreamTracks(stream: MediaStream) {
+  try {
+    stream.getTracks().forEach((track) => track.stop());
+  } catch (cause) {
+    console.warn('useCustomAudioSource: stopping tracks failed', cause);
+  }
+}
+
+function toError(cause: unknown): Error {
+  return cause instanceof Error ? cause : new Error(String(cause));
+}
+
+/**
+ * Publish your own audio to Fishjam.
+ *
+ * Creates a custom audio track, publishes it, and cleans it up — you supply
+ * the PCM from any source (a synthesizer, a decoder, an audio pipeline) via
+ * `pushAudioSamples`. The published track behaves like a live microphone:
+ * pauses in pushing are fine and play as silence. It is independent of
+ * {@link useMicrophone} and does not involve the device microphone in any way —
+ * publishing it does not trigger the recording permission.
+ *
+ * Remote peers receive the track with metadata type `"customAudio"`
+ * (`usePeers` exposes it under `customAudioTracks`).
+ *
+ * ```tsx
+ * const { startStreaming, stopStreaming, pushAudioSamples } = useCustomAudioSource();
+ *
+ * // e.g. from react-native-audio-api's AudioRecorder:
+ * recorder.onAudioReady({ sampleRate: 48000, bufferLength: 4800, channelCount: 1 },
+ *     ({ buffer }) => pushAudioSamples(buffer.getChannelData(0)));
+ * ```
+ *
+ * Requires the New Architecture; `startStreaming` reports an error on the old
+ * architecture.
+ *
+ * @group Hooks
+ */
+export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): UseCustomAudioSourceResult {
+  const sourceId = options?.sourceId ?? DEFAULT_SOURCE_ID;
+  const sampleRateHz = options?.sampleRateHz ?? DEFAULT_SAMPLE_RATE_HZ;
+  const channelCount = options?.channelCount ?? DEFAULT_CHANNEL_COUNT;
+
+  const { setStream } = useCustomSource(sourceId);
+  // Read through a ref so start/stop/unmount always use the latest setStream
+  // without retriggering their memoization when the provider re-renders.
+  const setStreamRef = useRef(setStream);
+  useEffect(() => {
+    setStreamRef.current = setStream;
+  });
+
+  const sessionRef = useRef<StreamingSession | null>(null);
+  const [isStreaming, setIsStreaming] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const startStreaming = useCallback(async () => {
+    if (sessionRef.current) {
+      return;
+    }
+    const session: StreamingSession = { created: null, cancelled: false };
+    sessionRef.current = session;
+    setError(null);
+    try {
+      const created = await createCustomAudioTrack({
+        sampleRateHz,
+        channelCount,
+      });
+      if (session.cancelled) {
+        // Stopped (or unmounted) while creating — discard the just-built track.
+        stopStreamTracks(created.stream);
+        return;
+      }
+      session.created = created;
+      await setStreamRef.current(created.stream);
+      if (session.cancelled) {
+        // stopStreaming already unpublished and released the track.
+        return;
+      }
+      setIsStreaming(true);
+    } catch (cause) {
+      if (session.created) {
+        stopStreamTracks(session.created.stream);
+      }
+      if (!session.cancelled) {
+        sessionRef.current = null;
+        setError(toError(cause));
+      }
+    }
+  }, [sampleRateHz, channelCount]);
+
+  const stopStreaming = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) {
+      return;
+    }
+    session.cancelled = true;
+    sessionRef.current = null;
+    setIsStreaming(false);
+    if (session.created) {
+      try {
+        await setStreamRef.current(null);
+      } catch (cause) {
+        setError(toError(cause));
+      } finally {
+        stopStreamTracks(session.created.stream);
+      }
+    }
+  }, []);
+
+  useEffect(
+    () => () => {
+      const session = sessionRef.current;
+      if (!session) {
+        return;
+      }
+      session.cancelled = true;
+      sessionRef.current = null;
+      const created = session.created;
+      if (created) {
+        // Unpublish before stopping the tracks, so a publish call still queued
+        // behind other custom sources never runs on an already-stopped track.
+        // Failures are ignored — the provider may be unmounting too and there
+        // is no surface left to report to.
+        setStreamRef
+          .current(null)
+          .catch(() => {})
+          .finally(() => stopStreamTracks(created.stream));
+      }
+    },
+    [],
+  );
+
+  const pushAudioSamples = useCallback((samples: Float32Array | Int16Array) => {
+    const track = sessionRef.current?.created?.track;
+    if (!track) {
+      // Not streaming — drop, matching live-source semantics.
+      return;
+    }
+    pushAudioSamplesToTrack(track, samples);
+  }, []);
+
+  return { isStreaming, startStreaming, stopStreaming, pushAudioSamples, error };
+}

--- a/packages/mobile-client/src/hooks/useCustomAudioSource.ts
+++ b/packages/mobile-client/src/hooks/useCustomAudioSource.ts
@@ -1,8 +1,8 @@
 import {
   createCustomAudioTrack,
+  type CustomAudioTrack,
   type CustomAudioTrackResult,
   type MediaStream,
-  pushAudioSamples as pushAudioSamplesToTrack,
 } from '@fishjam-cloud/react-native-webrtc';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
@@ -37,6 +37,13 @@ export interface UseCustomAudioSourceResult {
   /** Whether the custom audio track is currently published. */
   isStreaming: boolean;
   /**
+   * Push handle for the published track; `null` until streaming starts. Hand
+   * it to `pushAudioSamples` whenever your source produces audio. The handle
+   * is plain and worklet-serializable, so it can be shared into a worklet and
+   * pushed from there directly — no thread hop.
+   */
+  track: CustomAudioTrack | null;
+  /**
    * Create the custom audio track and publish it. Once this resolves, pushed
    * samples are streamed to the room. No-op when already streaming.
    */
@@ -45,14 +52,6 @@ export interface UseCustomAudioSourceResult {
    * Unpublish and release the custom audio track. No-op when not streaming.
    */
   stopStreaming: () => Promise<void>;
-  /**
-   * Hand PCM to the published track. Call whenever your source produces
-   * audio, with any chunk size — the track re-paces it into a continuous
-   * stream, filling gaps with silence like a live microphone. `Float32Array`
-   * samples are expected in `[-1, 1]`; `Int16Array` is taken as-is. Safe to
-   * call anytime: samples pushed while not streaming are dropped.
-   */
-  pushAudioSamples: (samples: Float32Array | Int16Array) => void;
   /** The error that failed the last `startStreaming` or `stopStreaming` call, if any. */
   error: Error | null;
 }
@@ -87,12 +86,19 @@ function toError(cause: unknown): Error {
  * Remote peers receive the track with metadata type `"customAudio"`
  * (`usePeers` exposes it under `customAudioTracks`).
  *
+ * Push PCM with `pushAudioSamples` (from `@fishjam-cloud/react-native-client`)
+ * and the returned {@link UseCustomAudioSourceResult.track | track} handle —
+ * from the JS thread or from inside a worklet, with any chunk size. The track
+ * re-paces pushes into a continuous stream, filling gaps with silence like a
+ * live microphone. `Float32Array` samples are expected in `[-1, 1]`;
+ * `Int16Array` is taken as-is.
+ *
  * ```tsx
- * const { startStreaming, stopStreaming, pushAudioSamples } = useCustomAudioSource();
+ * const { startStreaming, stopStreaming, track } = useCustomAudioSource();
  *
  * // e.g. from react-native-audio-api's AudioRecorder:
  * recorder.onAudioReady({ sampleRate: 48000, bufferLength: 4800, channelCount: 1 },
- *     ({ buffer }) => pushAudioSamples(buffer.getChannelData(0)));
+ *     ({ buffer }) => track && pushAudioSamples(track, buffer.getChannelData(0)));
  * ```
  *
  * Requires the New Architecture; `startStreaming` reports an error on the old
@@ -114,7 +120,7 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
   });
 
   const sessionRef = useRef<StreamingSession | null>(null);
-  const [isStreaming, setIsStreaming] = useState(false);
+  const [track, setTrack] = useState<CustomAudioTrack | null>(null);
   const [error, setError] = useState<Error | null>(null);
 
   const startStreaming = useCallback(async () => {
@@ -140,7 +146,7 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
         // stopStreaming already unpublished and released the track.
         return;
       }
-      setIsStreaming(true);
+      setTrack(created.track);
     } catch (cause) {
       if (session.created) {
         stopStreamTracks(session.created.stream);
@@ -159,7 +165,7 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
     }
     session.cancelled = true;
     sessionRef.current = null;
-    setIsStreaming(false);
+    setTrack(null);
     if (session.created) {
       try {
         await setStreamRef.current(null);
@@ -194,14 +200,11 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
     [],
   );
 
-  const pushAudioSamples = useCallback((samples: Float32Array | Int16Array) => {
-    const track = sessionRef.current?.created?.track;
-    if (!track) {
-      // Not streaming — drop, matching live-source semantics.
-      return;
-    }
-    pushAudioSamplesToTrack(track, samples);
-  }, []);
-
-  return { isStreaming, startStreaming, stopStreaming, pushAudioSamples, error };
+  return {
+    isStreaming: track !== null,
+    track,
+    startStreaming,
+    stopStreaming,
+    error,
+  };
 }

--- a/packages/mobile-client/src/hooks/useCustomAudioSource.ts
+++ b/packages/mobile-client/src/hooks/useCustomAudioSource.ts
@@ -11,6 +11,7 @@ import { useCustomSource } from '../overrides/hooks';
 const DEFAULT_SOURCE_ID = 'customAudioSource';
 const DEFAULT_SAMPLE_RATE_HZ = 48000;
 const DEFAULT_CHANNEL_COUNT = 1;
+const DEFAULT_MAX_BUFFERED_DURATION_MS = 60_000;
 
 /**
  * Settings for {@link useCustomAudioSource}, fixed for the lifetime of a
@@ -19,18 +20,29 @@ const DEFAULT_CHANNEL_COUNT = 1;
 export interface UseCustomAudioSourceOptions {
   /**
    * Stable id identifying this custom source. Defaults to
-   * `"customAudioSource"`.
+   * `"customAudioSource"`. Every hook instance that streams at the same time
+   * needs its own id — two instances sharing one silently replace each
+   * other's published track.
    */
   sourceId?: string;
   /**
-   * Sample rate of the PCM you will push, in hertz. Push whatever your source
-   * produces natively — it is resampled downstream. Defaults to `48000`.
+   * Sample rate of the PCM you will push, in hertz. Must be a positive
+   * multiple of `100`. Push whatever your source produces natively — it is
+   * resampled downstream. Defaults to `48000`.
    */
   sampleRateHz?: number;
   /**
    * `1` for mono or `2` for interleaved stereo. Defaults to `1`.
    */
   channelCount?: 1 | 2;
+  /**
+   * How much pushed-but-not-yet-sent audio to hold, in milliseconds, before
+   * the oldest is dropped. The buffer drains in real time, so this is the
+   * furthest you can push ahead — for example a long text-to-speech utterance
+   * handed over in one call. Must be at least `10`. Defaults to `60000` (one
+   * minute).
+   */
+  maxBufferedDurationMs?: number;
 }
 
 export interface UseCustomAudioSourceResult {
@@ -44,8 +56,10 @@ export interface UseCustomAudioSourceResult {
    */
   track: CustomAudioTrack | null;
   /**
-   * Create the custom audio track and publish it. Once this resolves, pushed
-   * samples are streamed to the room. No-op when already streaming.
+   * Create the custom audio track and publish it. Once this resolves the
+   * track is registered — pushed samples are streamed to the room right away
+   * when the peer is connected, or automatically once it connects. No-op when
+   * already streaming.
    */
   startStreaming: () => Promise<void>;
   /**
@@ -59,6 +73,12 @@ export interface UseCustomAudioSourceResult {
 type StreamingSession = {
   created: CustomAudioTrackResult | null;
   cancelled: boolean;
+  /**
+   * The publish function bound to the sourceId this session started under.
+   * Teardown must use it (not the latest one) so a sourceId change mid-session
+   * still unpublishes the source that was actually published.
+   */
+  setStream: (stream: MediaStream | null) => Promise<void>;
 };
 
 function stopStreamTracks(stream: MediaStream) {
@@ -110,10 +130,13 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
   const sourceId = options?.sourceId ?? DEFAULT_SOURCE_ID;
   const sampleRateHz = options?.sampleRateHz ?? DEFAULT_SAMPLE_RATE_HZ;
   const channelCount = options?.channelCount ?? DEFAULT_CHANNEL_COUNT;
+  const maxBufferedDurationMs = options?.maxBufferedDurationMs ?? DEFAULT_MAX_BUFFERED_DURATION_MS;
 
   const { setStream } = useCustomSource(sourceId);
-  // Read through a ref so start/stop/unmount always use the latest setStream
-  // without retriggering their memoization when the provider re-renders.
+  // Read through a ref so startStreaming picks up the latest setStream without
+  // retriggering its memoization when the provider re-renders. Each session
+  // captures the function it started with, so stop/unmount tear down the
+  // sourceId that was actually published even if the option changed since.
   const setStreamRef = useRef(setStream);
   useEffect(() => {
     setStreamRef.current = setStream;
@@ -127,13 +150,14 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
     if (sessionRef.current) {
       return;
     }
-    const session: StreamingSession = { created: null, cancelled: false };
+    const session: StreamingSession = { created: null, cancelled: false, setStream: setStreamRef.current };
     sessionRef.current = session;
     setError(null);
     try {
       const created = await createCustomAudioTrack({
         sampleRateHz,
         channelCount,
+        maxBufferedDurationMs,
       });
       if (session.cancelled) {
         // Stopped (or unmounted) while creating — discard the just-built track.
@@ -141,7 +165,7 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
         return;
       }
       session.created = created;
-      await setStreamRef.current(created.stream);
+      await session.setStream(created.stream);
       if (session.cancelled) {
         // stopStreaming already unpublished and released the track.
         return;
@@ -156,7 +180,7 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
         setError(toError(cause));
       }
     }
-  }, [sampleRateHz, channelCount]);
+  }, [sampleRateHz, channelCount, maxBufferedDurationMs]);
 
   const stopStreaming = useCallback(async () => {
     const session = sessionRef.current;
@@ -168,7 +192,7 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
     setTrack(null);
     if (session.created) {
       try {
-        await setStreamRef.current(null);
+        await session.setStream(null);
       } catch (cause) {
         setError(toError(cause));
       } finally {
@@ -191,8 +215,8 @@ export function useCustomAudioSource(options?: UseCustomAudioSourceOptions): Use
         // behind other custom sources never runs on an already-stopped track.
         // Failures are ignored — the provider may be unmounting too and there
         // is no surface left to report to.
-        setStreamRef
-          .current(null)
+        session
+          .setStream(null)
           .catch(() => {})
           .finally(() => stopStreamTracks(created.stream));
       }

--- a/packages/mobile-client/src/index.ts
+++ b/packages/mobile-client/src/index.ts
@@ -37,6 +37,11 @@ export type {
 
 export { useForegroundService, type ForegroundServiceConfig } from './useForegroundService';
 export { useCameraPermissions, useMicrophonePermissions, type PermissionStatus } from './hooks/usePermissions';
+export {
+  useCustomAudioSource,
+  type UseCustomAudioSourceOptions,
+  type UseCustomAudioSourceResult,
+} from './hooks/useCustomAudioSource';
 
 export {
   InitializeDevicesSettings,

--- a/packages/mobile-client/src/index.ts
+++ b/packages/mobile-client/src/index.ts
@@ -23,11 +23,14 @@ export {
   stopPIP,
   AudioDeviceType,
   useAudioOutput,
+  pushAudioSamples,
 } from '@fishjam-cloud/react-native-webrtc';
 
 export type {
   CallKitAction,
   CallKitConfig,
+  CustomAudioSink,
+  CustomAudioTrack,
   MediaStream,
   MediaStreamTrack,
   AudioDevice,


### PR DESCRIPTION
## Description

- Bump `react-native-webrtc` submodule — pulls in `createCustomAudioTrack` / `pushAudioSamples` (fishjam-react-native-webrtc#68, FishjamWebRTC v124.0.2.3)
- `mobile-client`: add `useCustomAudioSource` — source-hook-family API for publishing app-generated PCM as a Fishjam audio track:
  - owns the track lifecycle: create → publish via `useCustomSource` → unpublish + release
  - returns a worklet-serializable `track` handle (`null` until streaming); producers push any-size `Float32Array`/`Int16Array` chunks via the worklet-safe `pushAudioSamples(track, samples)`, re-exported from the SDK — same handle-plus-module-function shape as the custom video family
- Validated end-to-end on iOS simulator: 440 Hz sine pushed from JS decoded on a web peer at 439.5 Hz (FFT), 0 packets lost; remote peers receive the track as `customAudio` (`usePeers().customAudioTracks`)

## Motivation and Context

Productizes the custom audio track primitive: lets apps publish synthesized or processed audio (e.g. from `react-native-audio-api`) without touching the device microphone.

## Documentation impact

- [x] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
