### PR TITLE
FCE-3577: add tsunami client lifecycle and disposal

### DIFF
--- a/packages/tsunami/package.json
+++ b/packages/tsunami/package.json
@@ -35,13 +35,16 @@
     "format:check": "prettier --check . --ignore-path ./.eslintignore",
     "lint": "eslint . --ext .ts,.tsx --fix",
     "lint:check": "eslint . --ext .ts,.tsx",
-    "test": "vitest run --passWithNoTests",
+    "test": "vitest run",
     "tsc": "tsc --noEmit"
   },
   "dependencies": {
-    "@fishjam-cloud/ts-client": "workspace:*"
+    "@fishjam-cloud/ts-client": "workspace:*",
+    "events": "^3.3.0",
+    "typed-emitter": "^2.1.0"
   },
   "devDependencies": {
+    "@types/events": "^3.0.3",
     "eslint": "^8.57.1",
     "prettier": "^3.5.3",
     "typescript": "^5.8.3",

--- a/packages/tsunami/src/ClientResourceScope.ts
+++ b/packages/tsunami/src/ClientResourceScope.ts
@@ -53,7 +53,7 @@ export class ClientResourceScope {
    * rejections from becoming unhandled.
    */
   public run<T>(operation: (signal: AbortSignal) => PromiseLike<T>): Promise<T> {
-    this.assertActive();
+    if (this.disposed) return Promise.reject(this.getDisposedError());
 
     let result: PromiseLike<T>;
     try {

--- a/packages/tsunami/src/ClientResourceScope.ts
+++ b/packages/tsunami/src/ClientResourceScope.ts
@@ -1,0 +1,121 @@
+import { ClientDisposedError } from "./errors";
+
+type Cleanup = () => void;
+
+/**
+ * Internal disposal boundary shared by FishjamClient and its composed
+ * controllers.
+ */
+export class ClientResourceScope {
+  private readonly abortController = new AbortController();
+  private readonly cleanups = new Set<Cleanup>();
+  private readonly tracks = new Set<MediaStreamTrack>();
+
+  private disposed = false;
+  private disposedError: ClientDisposedError | null = null;
+
+  public get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  public get signal(): AbortSignal {
+    return this.abortController.signal;
+  }
+
+  public assertActive(): void {
+    if (this.disposed) throw this.getDisposedError();
+  }
+
+  /** Registers cleanup that must run when the client is disposed. */
+  public registerCleanup(cleanup: Cleanup): Cleanup {
+    this.assertActive();
+    this.cleanups.add(cleanup);
+
+    return () => {
+      this.cleanups.delete(cleanup);
+    };
+  }
+
+  /** Registers a track whose lifecycle is owned by a core controller. */
+  public registerTrack(track: MediaStreamTrack): Cleanup {
+    this.assertActive();
+    this.tracks.add(track);
+
+    return () => {
+      this.tracks.delete(track);
+    };
+  }
+
+  /**
+   * Runs an operation within the client disposal boundary. The public promise
+   * rejects on disposal even when the underlying platform operation cannot be
+   * cancelled. The underlying promise remains observed to prevent late
+   * rejections from becoming unhandled.
+   */
+  public run<T>(operation: (signal: AbortSignal) => PromiseLike<T>): Promise<T> {
+    this.assertActive();
+
+    let result: PromiseLike<T>;
+    try {
+      result = operation(this.signal);
+    } catch (error: unknown) {
+      return Promise.reject(this.disposed ? this.getDisposedError() : error);
+    }
+
+    return new Promise<T>((resolve, reject) => {
+      const onAbort = () => reject(this.getDisposedError());
+      if (this.disposed) {
+        onAbort();
+      } else {
+        this.signal.addEventListener("abort", onAbort, { once: true });
+      }
+
+      Promise.resolve(result).then(
+        (value) => {
+          this.signal.removeEventListener("abort", onAbort);
+          if (this.disposed) {
+            reject(this.getDisposedError());
+          } else {
+            resolve(value);
+          }
+        },
+        (error: unknown) => {
+          this.signal.removeEventListener("abort", onAbort);
+          reject(this.disposed ? this.getDisposedError() : error);
+        },
+      );
+    });
+  }
+
+  public dispose(): void {
+    if (this.disposed) return;
+
+    this.disposed = true;
+    this.disposedError = new ClientDisposedError();
+    this.abortController.abort(this.disposedError);
+
+    for (const track of this.tracks) {
+      try {
+        track.stop();
+      } catch {
+        // One broken track must not prevent the remaining resources from being released.
+      }
+    }
+
+    const cleanups = [...this.cleanups].reverse();
+    for (const cleanup of cleanups) {
+      try {
+        cleanup();
+      } catch {
+        // Disposal is best-effort and must continue through the full registry.
+      }
+    }
+
+    this.tracks.clear();
+    this.cleanups.clear();
+  }
+
+  private getDisposedError(): ClientDisposedError {
+    return (this.disposedError ??= new ClientDisposedError());
+  }
+}

--- a/packages/tsunami/src/FishjamClient.test.ts
+++ b/packages/tsunami/src/FishjamClient.test.ts
@@ -1,0 +1,287 @@
+import { type ConnectConfig, FishjamClient as TsClient, type GenericMetadata } from "@fishjam-cloud/ts-client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ClientResourceScope } from "./ClientResourceScope";
+import { ClientDisposedError } from "./errors";
+import { FishjamClient } from "./FishjamClient";
+
+const mediaStreamConstructor = vi.fn();
+
+class FakeMediaStream {
+  private readonly tracks: MediaStreamTrack[] = [];
+
+  public constructor() {
+    mediaStreamConstructor();
+  }
+
+  public addTrack(track: MediaStreamTrack): void {
+    this.tracks.push(track);
+  }
+
+  public removeTrack(track: MediaStreamTrack): void {
+    const index = this.tracks.indexOf(track);
+    if (index !== -1) this.tracks.splice(index, 1);
+  }
+
+  public getTracks(): MediaStreamTrack[] {
+    return [...this.tracks];
+  }
+}
+
+function createTrack(stop = vi.fn()): MediaStreamTrack {
+  return { stop } as unknown as MediaStreamTrack;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+const connectConfig: ConnectConfig<GenericMetadata> = {
+  peerMetadata: undefined,
+  token: "token",
+  url: "https://fishjam.example",
+};
+
+describe("FishjamClient lifecycle", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mediaStreamConstructor.mockClear();
+    vi.stubGlobal("MediaStream", FakeMediaStream);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("has inert construction", () => {
+    const WebSocketMock = vi.fn();
+    const mediaDevices = {
+      addEventListener: vi.fn(),
+      enumerateDevices: vi.fn(),
+      getUserMedia: vi.fn(),
+    };
+    const addGlobalEventListener = vi.fn();
+
+    vi.stubGlobal("WebSocket", WebSocketMock);
+    vi.stubGlobal("navigator", { mediaDevices });
+    vi.stubGlobal("addEventListener", addGlobalEventListener);
+
+    const timerCount = vi.getTimerCount();
+    const client = new FishjamClient();
+
+    expect(WebSocketMock).not.toHaveBeenCalled();
+    expect(mediaDevices.enumerateDevices).not.toHaveBeenCalled();
+    expect(mediaDevices.getUserMedia).not.toHaveBeenCalled();
+    expect(mediaDevices.addEventListener).not.toHaveBeenCalled();
+    expect(addGlobalEventListener).not.toHaveBeenCalled();
+    expect(mediaStreamConstructor).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(timerCount);
+
+    client.dispose();
+  });
+
+  it("stops controller-owned tracks and runs every registered cleanup", () => {
+    const resources = new ClientResourceScope();
+    const firstStop = vi.fn(() => {
+      throw new Error("broken track");
+    });
+    const secondStop = vi.fn();
+    const firstCleanup = vi.fn();
+    const secondCleanup = vi.fn(() => {
+      throw new Error("broken cleanup");
+    });
+
+    const firstTrack = createTrack(firstStop);
+    const secondTrack = createTrack(secondStop);
+    resources.registerCleanup(firstCleanup);
+    resources.registerCleanup(secondCleanup);
+    resources.registerTrack(firstTrack);
+    resources.registerTrack(secondTrack);
+
+    resources.dispose();
+
+    expect(firstStop).toHaveBeenCalledOnce();
+    expect(secondStop).toHaveBeenCalledOnce();
+    expect(firstCleanup).toHaveBeenCalledOnce();
+    expect(secondCleanup).toHaveBeenCalledOnce();
+    expect(resources.isDisposed).toBe(true);
+
+    resources.dispose();
+    expect(firstStop).toHaveBeenCalledOnce();
+    expect(secondStop).toHaveBeenCalledOnce();
+    expect(firstCleanup).toHaveBeenCalledOnce();
+    expect(secondCleanup).toHaveBeenCalledOnce();
+  });
+
+  it("tears down ts-client and drops listeners exactly once", async () => {
+    vi.spyOn(TsClient.prototype, "connect").mockResolvedValue();
+    const disconnect = vi.spyOn(TsClient.prototype, "disconnect");
+    const cleanup = vi.spyOn(TsClient.prototype, "cleanup");
+    const client = new FishjamClient();
+    client.on("joined", vi.fn());
+    await client.connect(connectConfig);
+
+    client.dispose();
+
+    expect(client.eventNames()).toEqual([]);
+    expect(client.isDisposed).toBe(true);
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
+
+    client.dispose();
+    expect(disconnect).toHaveBeenCalledOnce();
+    expect(cleanup).toHaveBeenCalledOnce();
+  });
+
+  it("unsubscribes resources registered through the wrapped client", () => {
+    const unsubscribe = vi.fn();
+    vi.spyOn(TsClient.prototype, "subscribeData").mockReturnValue(unsubscribe);
+    const client = new FishjamClient();
+
+    const removeSubscription = client.subscribeData(vi.fn(), { reliable: true });
+    client.dispose();
+    removeSubscription();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("rejects an in-flight connect when disposed", async () => {
+    const connection = deferred<void>();
+    vi.spyOn(TsClient.prototype, "connect").mockReturnValue(connection.promise);
+    const client = new FishjamClient();
+
+    const result = client.connect(connectConfig);
+    client.dispose();
+
+    await expect(result).rejects.toBeInstanceOf(ClientDisposedError);
+
+    connection.resolve();
+    await Promise.resolve();
+  });
+
+  it("tears down resources created after reentrant disposal during connect", async () => {
+    let resourceOpen = false;
+    const disconnect = vi.spyOn(TsClient.prototype, "disconnect").mockImplementation(() => {
+      resourceOpen = false;
+    });
+    vi.spyOn(TsClient.prototype, "connect").mockImplementation(function (this: TsClient<GenericMetadata>) {
+      this.emit("connectionStarted");
+      resourceOpen = true;
+      return Promise.resolve();
+    });
+    const client = new FishjamClient();
+    client.on("connectionStarted", () => client.dispose());
+
+    await expect(client.connect(connectConfig)).rejects.toBeInstanceOf(ClientDisposedError);
+
+    expect(resourceOpen).toBe(false);
+    expect(disconnect).toHaveBeenCalledTimes(2);
+  });
+
+  it("forwards signalling events without losing once semantics", async () => {
+    vi.spyOn(TsClient.prototype, "connect").mockResolvedValue();
+    const client = new FishjamClient();
+    const joined = vi.fn();
+    client.once("joined", joined);
+    await client.connect(connectConfig);
+
+    client.emit("joined", "peer-id", [], []);
+    client.emit("joined", "peer-id", [], []);
+
+    expect(joined).toHaveBeenCalledOnce();
+  });
+
+  it("does not take ownership of tracks passed through the signalling seam", async () => {
+    const publication = deferred<string>();
+    vi.spyOn(TsClient.prototype, "addTrack").mockReturnValue(publication.promise);
+    const client = new FishjamClient();
+    const stop = vi.fn();
+    const track = createTrack(stop);
+
+    const result = client.addTrack(track);
+    client.dispose();
+
+    expect(stop).not.toHaveBeenCalled();
+    await expect(result).rejects.toBeInstanceOf(ClientDisposedError);
+
+    publication.resolve("late-track-id");
+    await Promise.resolve();
+  });
+
+  it("exposes the disposal reason to controller operations", async () => {
+    const operation = deferred<void>();
+    const resources = new ClientResourceScope();
+    let lifecycleSignal: AbortSignal | undefined;
+
+    const result = resources.run((signal) => {
+      lifecycleSignal = signal;
+      return operation.promise;
+    });
+    resources.dispose();
+
+    expect(lifecycleSignal?.aborted).toBe(true);
+    expect(lifecycleSignal?.reason).toBeInstanceOf(ClientDisposedError);
+    await expect(result).rejects.toBe(lifecycleSignal?.reason);
+
+    operation.reject(new Error("late failure"));
+    await Promise.resolve();
+  });
+
+  it("observes an operation promise returned after synchronous disposal", async () => {
+    const operation = deferred<void>();
+    const then = vi.spyOn(operation.promise, "then");
+    const resources = new ClientResourceScope();
+
+    const result = resources.run(() => {
+      resources.dispose();
+      return operation.promise;
+    });
+
+    await expect(result).rejects.toBeInstanceOf(ClientDisposedError);
+    expect(then).toHaveBeenCalledOnce();
+
+    operation.reject(new Error("late failure"));
+    await Promise.resolve();
+  });
+
+  it("turns a synchronous operation failure into a rejected operation promise", async () => {
+    const resources = new ClientResourceScope();
+    const failure = new Error("platform failure");
+
+    const result = resources.run(() => {
+      throw failure;
+    });
+
+    await expect(result).rejects.toBe(failure);
+  });
+
+  it("rejects connect after terminal disposal without touching ts-client", async () => {
+    const connect = vi.spyOn(TsClient.prototype, "connect");
+    const client = new FishjamClient();
+    client.dispose();
+
+    await expect(client.connect(connectConfig)).rejects.toBeInstanceOf(ClientDisposedError);
+    expect(connect).not.toHaveBeenCalled();
+  });
+
+  it("cancels a reconnect timer already scheduled by ts-client", async () => {
+    vi.spyOn(TsClient.prototype, "connect").mockResolvedValue();
+    const client = new FishjamClient();
+    await client.connect(connectConfig);
+
+    client.emit("socketError", new Event("error"));
+    expect(vi.getTimerCount()).toBe(1);
+
+    client.dispose();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/tsunami/src/FishjamClient.test.ts
+++ b/packages/tsunami/src/FishjamClient.test.ts
@@ -264,6 +264,25 @@ describe("FishjamClient lifecycle", () => {
     await expect(result).rejects.toBe(failure);
   });
 
+  it("rejects a non-async operation after disposal instead of throwing synchronously", async () => {
+    const addTrack = vi.spyOn(TsClient.prototype, "addTrack");
+    const client = new FishjamClient();
+    client.dispose();
+
+    let thrownSynchronously = false;
+    let result: Promise<string>;
+    try {
+      result = client.addTrack(createTrack());
+    } catch {
+      thrownSynchronously = true;
+      result = Promise.reject(new Error("unreachable"));
+    }
+
+    expect(thrownSynchronously).toBe(false);
+    await expect(result).rejects.toBeInstanceOf(ClientDisposedError);
+    expect(addTrack).not.toHaveBeenCalled();
+  });
+
   it("rejects connect after terminal disposal without touching ts-client", async () => {
     const connect = vi.spyOn(TsClient.prototype, "connect");
     const client = new FishjamClient();

--- a/packages/tsunami/src/FishjamClient.ts
+++ b/packages/tsunami/src/FishjamClient.ts
@@ -1,0 +1,282 @@
+import {
+  type BandwidthLimit,
+  type Component,
+  type ConnectConfig,
+  type CreateConfig,
+  type DataCallback,
+  type DataChannelOptions,
+  FishjamClient as TsClient,
+  type FishjamTrackContext,
+  type GenericMetadata,
+  type MessageEvents,
+  type Peer,
+  type SimulcastConfig,
+  type TrackBandwidthLimit,
+  type TrackMetadata,
+  type Variant,
+} from "@fishjam-cloud/ts-client";
+import { EventEmitter } from "events";
+import type TypedEmitter from "typed-emitter";
+
+import { ClientResourceScope } from "./ClientResourceScope";
+
+type LegacyClientInternals<PeerMetadata> = {
+  reconnectManager?: { reset(metadata: PeerMetadata): void };
+  sendStatisticsInterval?: ReturnType<typeof setInterval>;
+};
+
+/**
+ * Framework-agnostic Fishjam SDK client.
+ *
+ * Construction only allocates in-memory state. The signalling client and all
+ * platform resources are created behind explicit operations. Once
+ * {@link dispose} is called, the instance is terminal and must be replaced.
+ * The code that creates an instance owns it and is responsible for disposing
+ * it; sharing an instance does not transfer that ownership.
+ */
+export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = GenericMetadata> extends (EventEmitter as {
+  new <P, S>(): TypedEmitter<MessageEvents<P, S>>;
+})<PeerMetadata, ServerMetadata> {
+  private readonly config: CreateConfig | undefined;
+  private readonly resources = new ClientResourceScope();
+
+  private tsClient: TsClient<PeerMetadata, ServerMetadata> | null = null;
+
+  public constructor(config?: CreateConfig) {
+    super();
+    this.config = config;
+  }
+
+  public get isDisposed(): boolean {
+    return this.resources.isDisposed;
+  }
+
+  /** Signalling initialization status retained for ts-client compatibility. */
+  public get status(): TsClient<PeerMetadata, ServerMetadata>["status"] {
+    return this.tsClient?.status ?? "new";
+  }
+
+  public emit<Event extends keyof MessageEvents<PeerMetadata, ServerMetadata>>(
+    event: Event,
+    ...args: Parameters<MessageEvents<PeerMetadata, ServerMetadata>[Event]>
+  ): boolean;
+  public emit(event: string | symbol, ...args: unknown[]): boolean {
+    if (this.tsClient) return (this.tsClient as EventEmitter).emit(event, ...args);
+    return EventEmitter.prototype.emit.call(this, event, ...args);
+  }
+
+  public async connect(config: ConnectConfig<PeerMetadata>): Promise<void> {
+    return this.resources.run(() => {
+      const tsClient = this.getTsClient();
+
+      try {
+        return tsClient.connect(config);
+      } finally {
+        // A synchronous connection event can dispose the wrapper before
+        // ts-client finishes connect(). Tear it down again in case connect()
+        // created resources after the first disposal pass.
+        if (this.resources.isDisposed) this.teardownTsClient(tsClient);
+      }
+    });
+  }
+
+  public async getStatistics(selector?: MediaStreamTrack | null): Promise<RTCStatsReport> {
+    return this.resources.run(() => this.tsClient?.getStatistics(selector) ?? Promise.resolve(new Map()));
+  }
+
+  public getRemoteTracks(): Readonly<Record<string, FishjamTrackContext>> {
+    return this.tsClient?.getRemoteTracks() ?? {};
+  }
+
+  public getRemotePeers(): Record<string, Peer<PeerMetadata, ServerMetadata>> {
+    return this.tsClient?.getRemotePeers() ?? {};
+  }
+
+  public getRemoteComponents(): Record<string, Component> {
+    return this.tsClient?.getRemoteComponents() ?? {};
+  }
+
+  public getLocalPeer(): Peer<PeerMetadata, ServerMetadata> | null {
+    return this.tsClient?.getLocalPeer() ?? null;
+  }
+
+  public getBandwidthEstimation(): bigint {
+    this.resources.assertActive();
+    if (!this.tsClient) throw new Error("WebRTC is not initialized");
+    return this.tsClient.getBandwidthEstimation();
+  }
+
+  public addTrack(
+    track: MediaStreamTrack,
+    trackMetadata?: TrackMetadata,
+    simulcastConfig?: SimulcastConfig,
+    maxBandwidth?: TrackBandwidthLimit,
+  ): Promise<string> {
+    return this.resources.run(() => this.getTsClient().addTrack(track, trackMetadata, simulcastConfig, maxBandwidth));
+  }
+
+  public async replaceTrack(trackId: string, newTrack: MediaStreamTrack | null): Promise<void> {
+    return this.resources.run(() => this.getTsClient().replaceTrack(trackId, newTrack));
+  }
+
+  public async setTrackBandwidth(trackId: string, bandwidth: BandwidthLimit): Promise<boolean> {
+    return this.resources.run(() => this.getTsClient().setTrackBandwidth(trackId, bandwidth));
+  }
+
+  public async setEncodingBandwidth(trackId: string, rid: Variant, bandwidth: BandwidthLimit): Promise<boolean> {
+    return this.resources.run(() => this.getTsClient().setEncodingBandwidth(trackId, rid, bandwidth));
+  }
+
+  public removeTrack(trackId: string): Promise<void> {
+    return this.resources.run(() => this.getTsClient().removeTrack(trackId));
+  }
+
+  public setTargetTrackEncoding(trackId: string, encoding: Variant): void {
+    this.resources.assertActive();
+    this.getTsClient().setTargetTrackEncoding(trackId, encoding);
+  }
+
+  public enableTrackEncoding(trackId: string, encoding: Variant): Promise<void> {
+    return this.resources.run(() => this.getTsClient().enableTrackEncoding(trackId, encoding));
+  }
+
+  public disableTrackEncoding(trackId: string, encoding: Variant): Promise<void> {
+    return this.resources.run(() => this.getTsClient().disableTrackEncoding(trackId, encoding));
+  }
+
+  public updatePeerMetadata = (peerMetadata: PeerMetadata): void => {
+    this.resources.assertActive();
+    this.getTsClient().updatePeerMetadata(peerMetadata);
+  };
+
+  public updateTrackMetadata = (trackId: string, trackMetadata: TrackMetadata): void => {
+    this.resources.assertActive();
+    this.getTsClient().updateTrackMetadata(trackId, trackMetadata);
+  };
+
+  public isReconnecting(): boolean {
+    return this.tsClient?.isReconnecting() ?? false;
+  }
+
+  public getDataChannelsReadiness(): boolean {
+    return this.tsClient?.getDataChannelsReadiness() ?? false;
+  }
+
+  public leave = (): void => {
+    this.resources.assertActive();
+    this.getTsClient().leave();
+  };
+
+  public createDataChannels(): Promise<void> {
+    return this.resources.run(() => this.getTsClient().createDataChannels());
+  }
+
+  public publishData(data: Uint8Array, options: DataChannelOptions): void {
+    this.resources.assertActive();
+    this.getTsClient().publishData(data, options);
+  }
+
+  public subscribeData(callback: DataCallback, options: DataChannelOptions): () => void {
+    this.resources.assertActive();
+
+    const unsubscribe = this.getTsClient().subscribeData(callback, options);
+    let subscribed = true;
+    const cleanup = () => {
+      if (!subscribed) return;
+      subscribed = false;
+      unsubscribe();
+    };
+    const unregisterCleanup = this.resources.registerCleanup(cleanup);
+
+    return () => {
+      unregisterCleanup();
+      cleanup();
+    };
+  }
+
+  public async getLocalTrackAudioLevel(trackId: string): Promise<{ level: number } | null> {
+    return this.resources.run(() => this.tsClient?.getLocalTrackAudioLevel(trackId) ?? Promise.resolve(null));
+  }
+
+  /**
+   * Releases every resource owned by this instance. This operation is
+   * synchronous, idempotent, and terminal.
+   */
+  public dispose(): void {
+    if (this.resources.isDisposed) return;
+
+    this.resources.dispose();
+
+    const tsClient = this.tsClient;
+    if (tsClient) {
+      this.teardownTsClient(tsClient);
+      this.tsClient = null;
+    }
+
+    super.removeAllListeners();
+  }
+
+  public disconnect(): void {
+    if (this.resources.isDisposed) return;
+    this.tsClient?.disconnect();
+  }
+
+  public cleanup(): void {
+    if (this.resources.isDisposed) return;
+    this.tsClient?.cleanup();
+  }
+
+  private getTsClient(): TsClient<PeerMetadata, ServerMetadata> {
+    this.resources.assertActive();
+    if (this.tsClient) return this.tsClient;
+
+    const tsClient = new TsClient<PeerMetadata, ServerMetadata>(this.config);
+    const emitter = tsClient as EventEmitter;
+    const emit = emitter.emit.bind(emitter);
+    emitter.emit = (event: string | symbol, ...args: unknown[]) => {
+      const handledByTsClient = emit(event, ...args);
+      const handledByTsunami = EventEmitter.prototype.emit.call(this, event, ...args);
+      return handledByTsClient || handledByTsunami;
+    };
+
+    this.tsClient = tsClient;
+    return tsClient;
+  }
+
+  private teardownTsClient(tsClient: TsClient<PeerMetadata, ServerMetadata>): void {
+    this.stopLegacyBackgroundWork(tsClient);
+
+    try {
+      tsClient.disconnect();
+    } catch {
+      // Continue: listener cleanup must happen even if the signalling client fails.
+    }
+
+    try {
+      tsClient.cleanup();
+    } catch {
+      // Continue: all listeners still need to be dropped.
+    }
+
+    tsClient.removeAllListeners();
+  }
+
+  private stopLegacyBackgroundWork(tsClient: TsClient<PeerMetadata, ServerMetadata>): void {
+    // ts-client predates a holistic disposal API. Its cleanup() removes
+    // listeners but does not cancel an already scheduled reconnect or expose
+    // the statistics interval. Keep this compatibility bridge isolated here
+    // until the strangler migration removes the legacy implementation.
+    const internals = tsClient as unknown as LegacyClientInternals<PeerMetadata>;
+
+    try {
+      internals.reconnectManager?.reset(undefined as PeerMetadata);
+    } catch {
+      // The remaining teardown is still required if legacy internals change.
+    }
+
+    if (internals.sendStatisticsInterval !== undefined) {
+      clearInterval(internals.sendStatisticsInterval);
+      internals.sendStatisticsInterval = undefined;
+    }
+  }
+}

--- a/packages/tsunami/src/errors.ts
+++ b/packages/tsunami/src/errors.ts
@@ -1,0 +1,10 @@
+/**
+ * Thrown when an operation is attempted on a client that has reached the end
+ * of its lifecycle.
+ */
+export class ClientDisposedError extends Error {
+  public constructor() {
+    super("FishjamClient has been disposed and cannot be used again");
+    this.name = "ClientDisposedError";
+  }
+}

--- a/packages/tsunami/src/index.ts
+++ b/packages/tsunami/src/index.ts
@@ -3,6 +3,8 @@
  *
  * @packageDocumentation
  */
+export { ClientDisposedError } from "./errors";
+export { FishjamClient } from "./FishjamClient";
 export * from "@fishjam-cloud/ts-client";
 
 export type MiddlewareResult = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5471,8 +5471,11 @@ __metadata:
   resolution: "@fishjam-cloud/tsunami@workspace:packages/tsunami"
   dependencies:
     "@fishjam-cloud/ts-client": "workspace:*"
+    "@types/events": "npm:^3.0.3"
     eslint: "npm:^8.57.1"
+    events: "npm:^3.3.0"
     prettier: "npm:^3.5.3"
+    typed-emitter: "npm:^2.1.0"
     typescript: "npm:^5.8.3"
     vitest: "npm:^3.1.1"
   languageName: unknown


### PR DESCRIPTION
## Description

Adds the tsunami client lifecycle: inert construction, terminal/idempotent dispose(), resource ownership, and safe mid-operation abortion while wrapping ts-client unchanged. Includes lifecycle regression tests and package configuration updates.

## Motivation and Context

https://linear.app/swmansion/issue/FCE-3577

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
