### PR TITLE
Fix reportConnected tearing down a swapped-in call; pick up native race fixes

### DIFF
--- a/packages/mobile-client/src/voip/VoipProvider.tsx
+++ b/packages/mobile-client/src/voip/VoipProvider.tsx
@@ -123,10 +123,6 @@ export function VoipProvider({ onWaitingCallDeclined, isVideo = false, children 
 
   const startCall = useCallback(
     async (to: string, roomName: string) => {
-      if (currentCallRef.current) {
-        console.warn('Cannot start a call while another call is in progress');
-        return;
-      }
       const call: CurrentCall = {
         roomName,
         displayName: to,
@@ -153,9 +149,6 @@ export function VoipProvider({ onWaitingCallDeclined, isVideo = false, children 
   const reportConnected = useCallback(async () => {
     const call = currentCallRef.current;
     if (!call || call.startedAt != null || activationInFlightRef.current) {
-      return;
-    }
-    if (!pendingAnswerRequestIdRef.current && !call.isOutgoing) {
       return;
     }
     activationInFlightRef.current = true;

--- a/packages/mobile-client/src/voip/VoipProvider.tsx
+++ b/packages/mobile-client/src/voip/VoipProvider.tsx
@@ -166,7 +166,9 @@ export function VoipProvider({ onWaitingCallDeclined, isVideo = false, children 
         pendingAnswerRequestIdRef.current = null;
         const connected = await fulfillIncomingCallConnected(requestId);
         if (!connected) {
-          await endCall('failed');
+          if (currentCallRef.current === call) {
+            await endCall('failed');
+          }
           return;
         }
       } else if (call.isOutgoing) {
@@ -183,7 +185,9 @@ export function VoipProvider({ onWaitingCallDeclined, isVideo = false, children 
       setStatus('active');
     } catch (err) {
       console.error('Failed to activate call:', err);
-      await endCall('failed');
+      if (currentCallRef.current === call) {
+        await endCall('failed');
+      }
     } finally {
       activationInFlightRef.current = false;
     }

--- a/packages/mobile-client/src/voip/VoipProvider.tsx
+++ b/packages/mobile-client/src/voip/VoipProvider.tsx
@@ -123,6 +123,10 @@ export function VoipProvider({ onWaitingCallDeclined, isVideo = false, children 
 
   const startCall = useCallback(
     async (to: string, roomName: string) => {
+      if (currentCallRef.current) {
+        console.warn('Cannot start a call while another call is in progress');
+        return;
+      }
       const call: CurrentCall = {
         roomName,
         displayName: to,
@@ -149,6 +153,9 @@ export function VoipProvider({ onWaitingCallDeclined, isVideo = false, children 
   const reportConnected = useCallback(async () => {
     const call = currentCallRef.current;
     if (!call || call.startedAt != null || activationInFlightRef.current) {
+      return;
+    }
+    if (!pendingAnswerRequestIdRef.current && !call.isOutgoing) {
       return;
     }
     activationInFlightRef.current = true;


### PR DESCRIPTION
## Description

- **`reportConnected`'s failure branches end only their own call.** The fulfil-failed and catch branches ended whatever call was current after the native await, so a call-waiting swap mid-fulfil tore down the freshly accepted call. They now end the call only if the one captured at entry is still current — the same identity re-check the success path already does.
- **Submodule bump** to `fishjam-react-native-webrtc@9636038` — the CallKitManager/CallManager/VoipManager race fixes (fishjam-cloud/fishjam-react-native-webrtc#77). Merge that PR first so the pointer lands on `feature/voip-calls`.

## Motivation and Context

Found in a deep review of the VoIP call flow: an internal race between a call-waiting swap and an in-flight `reportConnected`, not avoidable by the app. Verified with `tsc --noEmit`, eslint, prettier, and an adversarial review pass.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
