### PR TITLE
Release v0.30.0-rc.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fishjam-web-sdk",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/ios-expo-voip/package.json
+++ b/packages/ios-expo-voip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/ios-expo-voip",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "AppDelegate glue for Fishjam VoIP on iOS — registers PushKit at launch and routes Siri/Recents call intents. Install alongside @fishjam-cloud/react-native-client when VoIP options are enabled.",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/mobile-client/package.json
+++ b/packages/mobile-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-native-client",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "React Native client library for Fishjam",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-client",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "React client library for Fishjam",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/react-native-custom-video-source/package.json
+++ b/packages/react-native-custom-video-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-native-custom-video-source",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "Publish your own video frames to Fishjam — forward native buffers or render into a WebGPU surface pool, from any frame source",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/react-native-vision-camera-source/package.json
+++ b/packages/react-native-vision-camera-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-native-vision-camera-source",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "VisionCamera frame outputs that publish camera frames to Fishjam — zero-copy forwarding and WebGPU-rendered video sources",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/ts-client/package.json
+++ b/packages/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/ts-client",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "Typescript client library for Fishjam",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/webrtc-client/package.json
+++ b/packages/webrtc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/webrtc-client",
-  "version": "0.29.0",
+  "version": "0.30.0-rc.0",
   "description": "Typescript client library for ExWebRTC/WebRTC endpoint in Membrane RTC Engine",
   "license": "Apache-2.0",
   "author": "Fishjam Team",


### PR DESCRIPTION
Bumps the SDK to `0.30.0-rc.0`, matching the `@fishjam-cloud/react-native-webrtc` prerelease in fishjam-cloud/fishjam-react-native-webrtc#79.

## Changes

- `0.29.0` -> `0.30.0-rc.0` in the root package and the seven published workspaces (`webrtc-client`, `ts-client`, `react-client`, `react-native-client`, `react-native-custom-video-source`, `react-native-vision-camera-source`, `ios-expo-voip`).

Cross-package deps are all `workspace:*`, so nothing else needs editing — Yarn resolves them at pack time. `yarn.lock` is unchanged (workspaces resolve to `0.0.0-use.local`) and `yarn install --immutable` passes.

Proto output is intentionally not regenerated here: `yarn gen:proto` pulls a newer `packages/protobufs/protos` commit and rewrites the `protoc` version banner, which is unrelated to a version bump.

## Order of operations

The `mobile-client`, `ios-expo-voip`, `custom-video-source` and `vision-camera-source` publish jobs run `check:webrtc-published`, which requires the `packages/react-native-webrtc` submodule to sit on a tag matching its own `package.json` version, with that version live on npm. So:

1. Merge fishjam-cloud/fishjam-react-native-webrtc#79 and publish `@fishjam-cloud/react-native-webrtc@0.30.0-rc.0` (prerelease, lands under the `rc` dist-tag).
2. Merge this PR.
3. Pin the submodule to `v0.30.0-rc.0` on `main` (separate commit, as in #570).
4. `gh release create v0.30.0-rc.0 --target main --generate-notes --prerelease` — publishing the release triggers `.github/workflows/release.yaml`, and `--prerelease` makes it publish under the `rc` npm tag so `latest` stays at `0.29.0`.