### PR TITLE
FCE-3578: add StateStore

### DIFF
--- a/packages/tsunami/src/index.ts
+++ b/packages/tsunami/src/index.ts
@@ -9,6 +9,7 @@ export { WebDeviceManager, type WebDeviceManagerOptions } from "./devices/WebDev
 export { type ErrorRecoverability, FishjamError } from "./errors/FishjamError";
 export { ClientDisposedError } from "./errors/lifecycleErrors";
 export { FishjamClient } from "./FishjamClient";
+export { StateStore, type StateStoreOptions, type StoreListener } from "./state/StateStore";
 export * from "@fishjam-cloud/ts-client";
 
 export type MiddlewareResult = {

--- a/packages/tsunami/src/state/StateStore.test.ts
+++ b/packages/tsunami/src/state/StateStore.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { StateStore } from "./StateStore";
+
+type TestState = {
+  counter: number;
+  label: string;
+  slice: { value: number };
+  otherSlice: { value: number };
+};
+
+const createTestStore = () =>
+  new StateStore<TestState>({
+    counter: 0,
+    label: "initial",
+    slice: { value: 1 },
+    otherSlice: { value: 2 },
+  });
+
+const awaitNotifications = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe("StateStore", () => {
+  describe("snapshot stability and structural sharing", () => {
+    it("returns the same snapshot object until state actually changes", () => {
+      const store = createTestStore();
+      const snapshotBefore = store.getState();
+
+      store.update({ counter: 0, label: "initial" });
+
+      expect(store.getState()).toBe(snapshotBefore);
+    });
+
+    it("does not notify listeners for a no-op update", async () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 0 });
+      await awaitNotifications();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("keeps references of slices an update did not touch", () => {
+      const store = createTestStore();
+      const untouchedSliceBefore = store.getState().otherSlice;
+
+      store.update({ slice: { value: 10 } });
+
+      expect(store.getState().otherSlice).toBe(untouchedSliceBefore);
+      expect(store.getState().slice).toEqual({ value: 10 });
+    });
+
+    it("replaces the snapshot object when a value changes", () => {
+      const store = createTestStore();
+      const snapshotBefore = store.getState();
+
+      store.update({ counter: 5 });
+
+      expect(store.getState()).not.toBe(snapshotBefore);
+      expect(store.getState().counter).toBe(5);
+    });
+  });
+
+  describe("notification batching", () => {
+    it("applies updates to the snapshot synchronously, before any notification", () => {
+      const store = createTestStore();
+
+      store.update({ counter: 1 });
+      store.update({ label: "changed" });
+
+      expect(store.getState().counter).toBe(1);
+      expect(store.getState().label).toBe("changed");
+    });
+
+    it("coalesces all same-tick updates into a single notification", async () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 1 });
+      store.update({ counter: 2 });
+      store.update({ label: "changed" });
+      await awaitNotifications();
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("lets the listener observe the final merged state", async () => {
+      const store = createTestStore();
+      let observedState: TestState | null = null;
+      store.subscribe(() => {
+        observedState = store.getState();
+      });
+
+      store.update({ counter: 1 });
+      store.update({ label: "changed" });
+      await awaitNotifications();
+
+      expect(observedState).toMatchObject({ counter: 1, label: "changed" });
+    });
+
+    it("notifies again for updates made in a later tick", async () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 1 });
+      await awaitNotifications();
+      store.update({ counter: 2 });
+      await awaitNotifications();
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("notifies again when a listener updates the store during a flush", async () => {
+      const store = createTestStore();
+      const notifiedCounters: number[] = [];
+      store.subscribe(() => {
+        const { counter } = store.getState();
+        notifiedCounters.push(counter);
+        if (counter === 1) store.update({ counter: 2 });
+      });
+
+      store.update({ counter: 1 });
+      await awaitNotifications();
+
+      expect(notifiedCounters).toEqual([1, 2]);
+    });
+
+    it("keeps notifying remaining listeners when one of them throws", async () => {
+      const listenerError = new Error("listener failure");
+      const onListenerError = vi.fn();
+      const store = new StateStore<TestState>(
+        { counter: 0, label: "initial", slice: { value: 1 }, otherSlice: { value: 2 } },
+        { onListenerError },
+      );
+      const throwingListener = vi.fn(() => {
+        throw listenerError;
+      });
+      const laterListener = vi.fn();
+      store.subscribe(throwingListener);
+      store.subscribe(laterListener);
+
+      store.update({ counter: 1 });
+      await awaitNotifications();
+
+      expect(throwingListener).toHaveBeenCalledTimes(1);
+      expect(laterListener).toHaveBeenCalledTimes(1);
+      expect(onListenerError).toHaveBeenCalledWith(listenerError);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("stops notifying after unsubscribe", async () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+
+      unsubscribe();
+      store.update({ counter: 1 });
+      await awaitNotifications();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("does not notify anyone after clear, even for an already-scheduled flush", async () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 1 });
+      store.clear();
+      await awaitNotifications();
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("subscribeToSlice", () => {
+    it("fires with the next and previous value when the selected slice changes", async () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      store.subscribeToSlice((state) => state.slice, sliceListener);
+      const previousSlice = store.getState().slice;
+
+      store.update({ slice: { value: 10 } });
+      await awaitNotifications();
+
+      expect(sliceListener).toHaveBeenCalledTimes(1);
+      expect(sliceListener).toHaveBeenCalledWith({ value: 10 }, previousSlice);
+    });
+
+    it("does not fire when only unrelated slices change", async () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      store.subscribeToSlice((state) => state.slice, sliceListener);
+
+      store.update({ counter: 1, otherSlice: { value: 20 } });
+      await awaitNotifications();
+
+      expect(sliceListener).not.toHaveBeenCalled();
+    });
+
+    it("skips intermediate values, delivering only the coalesced result", async () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      store.subscribeToSlice((state) => state.counter, sliceListener);
+
+      store.update({ counter: 1 });
+      store.update({ counter: 2 });
+      await awaitNotifications();
+
+      expect(sliceListener).toHaveBeenCalledTimes(1);
+      expect(sliceListener).toHaveBeenCalledWith(2, 0);
+    });
+
+    it("stops firing after unsubscribe", async () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      const unsubscribe = store.subscribeToSlice((state) => state.slice, sliceListener);
+
+      unsubscribe();
+      store.update({ slice: { value: 10 } });
+      await awaitNotifications();
+
+      expect(sliceListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generics threading", () => {
+    it("threads the state's type parameters through the store", () => {
+      type PeerMetadata = { displayName: string };
+      type ParameterizedState<Metadata> = { localPeer: { metadata: Metadata } | null };
+
+      const store = new StateStore<ParameterizedState<PeerMetadata>>({ localPeer: null });
+      const { localPeer } = store.getState();
+
+      expectTypeOf(localPeer?.metadata).toEqualTypeOf<PeerMetadata | undefined>();
+      expect(localPeer).toBeNull();
+    });
+  });
+});

--- a/packages/tsunami/src/state/StateStore.ts
+++ b/packages/tsunami/src/state/StateStore.ts
@@ -1,0 +1,91 @@
+export type StoreListener = () => void;
+
+export type StateStoreOptions = {
+  /** Handles a listener throwing during a flush; defaults to rethrowing asynchronously. */
+  onListenerError?: (error: unknown) => void;
+};
+
+/**
+ * Observable state container. Snapshots are stable (`getState` returns the
+ * same object until a value changes) and structurally shared (an update
+ * replaces only the slices it received). Notifications are coalesced to one
+ * per tick — one per awaited operation, not one per `update()` call.
+ */
+export class StateStore<TState extends object> {
+  private snapshot: TState;
+  private readonly listeners = new Set<StoreListener>();
+  private isNotificationScheduled = false;
+
+  public constructor(
+    initialState: TState,
+    private readonly options: StateStoreOptions = {},
+  ) {
+    this.snapshot = initialState;
+  }
+
+  public getState = (): TState => this.snapshot;
+
+  public subscribe = (listener: StoreListener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  /** Notifies only when the selected value changes (`Object.is`). */
+  public subscribeToSlice = <Slice>(
+    selector: (state: TState) => Slice,
+    listener: (slice: Slice, previousSlice: Slice) => void,
+  ): (() => void) => {
+    let lastSeenSlice = selector(this.snapshot);
+    return this.subscribe(() => {
+      const nextSlice = selector(this.snapshot);
+      if (Object.is(nextSlice, lastSeenSlice)) return;
+      const previousSlice = lastSeenSlice;
+      lastSeenSlice = nextSlice;
+      listener(nextSlice, previousSlice);
+    });
+  };
+
+  /** Applied synchronously; a call that changes nothing keeps the snapshot and notifies nobody. */
+  public update(partial: Partial<TState>): void {
+    const keys = Object.keys(partial) as (keyof TState)[];
+    const hasChange = keys.some((key) => partial[key] !== this.snapshot[key]);
+    if (!hasChange) return;
+
+    this.snapshot = { ...this.snapshot, ...partial };
+    this.scheduleNotification();
+  }
+
+  /** Drops all listeners; an already-scheduled notification becomes a no-op. */
+  public clear(): void {
+    this.listeners.clear();
+  }
+
+  private scheduleNotification(): void {
+    if (this.isNotificationScheduled) return;
+    this.isNotificationScheduled = true;
+
+    queueMicrotask(() => {
+      this.isNotificationScheduled = false;
+      for (const listener of [...this.listeners]) {
+        try {
+          listener();
+        } catch (error) {
+          this.handleListenerError(error);
+        }
+      }
+    });
+  }
+
+  private handleListenerError(error: unknown): void {
+    if (this.options.onListenerError) {
+      this.options.onListenerError(error);
+      return;
+    }
+    // Rethrow out-of-band: the error stays observable without starving other listeners.
+    queueMicrotask(() => {
+      throw error;
+    });
+  }
+}


### PR DESCRIPTION
## Description

The state store from RFC 0015 §2–3, as a standalone generic container (`StateStore<TState>`), with the two hard guarantees the framework adapters need:

- **Snapshot stability + structural sharing** — `getState()` returns the same object until a value actually changes; an update replaces only the top-level slices it received, so untouched slices keep their references and consumers can skip work with reference equality. A value-identical `update()` is a full no-op.
- **Batched notifications** — updates apply to the snapshot synchronously, but listeners are notified once per tick (microtask-coalesced). The RFC's "two awaited calls → one re-render" claim is corrected in the tsdoc: sequentially awaited operations resume in separate ticks and notify once *each*; collapsing those renders is the UI framework's job.

Plus `subscribeToSlice(selector, listener)` (fires on `Object.is` change of the selected value — the non-React consumption path), `clear()` for disposal wiring, and an `onListenerError` hook (default: rethrow out-of-band so one throwing subscriber can't starve the rest).

**Deliberately absent: `ClientState`.** The concrete state shape ships with its first writer (the client-wiring PR, then per-slice with each controller), per the land-with-first-consumer rule in `packages/tsunami/AGENTS.md` — its field shapes (e.g. error fields, post-FCE-3580) aren't knowable until those implementations exist.

## Motivation and Context

Everything downstream of RFC 0015 — client wiring, device controllers, the react-client migration — funnels state through this container, so its contract has to be right first. The stability guarantee is what makes `getState` safe to hand to `useSyncExternalStore` in the react adapter (an unstable snapshot loops it infinitely), and the same mechanism is what slice-level re-render skipping is built on.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
