### PR TITLE
Rename VoIP status to callStatus

### DIFF
--- a/examples/mobile-client/voip-call/app/App.tsx
+++ b/examples/mobile-client/voip-call/app/App.tsx
@@ -25,7 +25,7 @@ import { UserProvider } from './src/user/UserProvider';
 
 function Main({ sendSignalRef }: { sendSignalRef: SendSignalRef }) {
   const { username, isLoading } = useUser();
-  const { status, lastEndedReason } = useVoIP();
+  const { callStatus, lastEndedReason } = useVoIP();
 
   useRequestPermissions();
   useCallSignaling(sendSignalRef);
@@ -42,7 +42,7 @@ function Main({ sendSignalRef }: { sendSignalRef: SendSignalRef }) {
   // Checked before the session gates below: a call can exist while the user session
   // is still loading (answering a VoIP push right after a cold start) or missing
   // (still registered for pushes after a logout), and it must connect regardless.
-  if (status === 'connecting' || status === 'active') {
+  if (callStatus === 'connecting' || callStatus === 'active') {
     return <CallScreen />;
   }
 

--- a/examples/mobile-client/voip-call/app/src/hooks/useCallSignaling.ts
+++ b/examples/mobile-client/voip-call/app/src/hooks/useCallSignaling.ts
@@ -17,7 +17,7 @@ export type SendSignal = (msg: Record<string, unknown>) => void;
 export type SendSignalRef = MutableRefObject<SendSignal | undefined>;
 
 export function useCallSignaling(sendSignalRef: SendSignalRef): void {
-  const { endCall, currentCall, status, lastEndedReason } = useVoIP();
+  const { endCall, currentCall, callStatus, lastEndedReason } = useVoIP();
   const { username } = useUser();
 
   const socketRef = useRef<WebSocket | null>(null);
@@ -82,13 +82,16 @@ export function useCallSignaling(sendSignalRef: SendSignalRef): void {
   // Detect the local user ending a call before it connected, and notify the
   // other party so their ringing UI can be dismissed.
 
-  const prevRef = useRef<{ status: VoIPCallStatus; call: CurrentCall | null }>({
-    status,
+  const prevRef = useRef<{
+    callStatus: VoIPCallStatus;
+    call: CurrentCall | null;
+  }>({
+    callStatus,
     call: currentCall,
   });
 
   useEffect(() => {
-    const { status: prevStatus, call: prevCall } = prevRef.current;
+    const { callStatus: prevStatus, call: prevCall } = prevRef.current;
 
     const userEndedCall =
       lastEndedReason === 'local' || lastEndedReason === 'rejected';
@@ -96,7 +99,7 @@ export function useCallSignaling(sendSignalRef: SendSignalRef): void {
     if (
       prevCall &&
       prevCall.startedAt === null &&
-      status === 'available' &&
+      callStatus === 'available' &&
       userEndedCall
     ) {
       // Caller cancelled an outgoing call that was still ringing.
@@ -117,6 +120,6 @@ export function useCallSignaling(sendSignalRef: SendSignalRef): void {
       }
     }
 
-    prevRef.current = { status, call: currentCall };
-  }, [status, currentCall, lastEndedReason, sendSignal]);
+    prevRef.current = { callStatus, call: currentCall };
+  }, [callStatus, currentCall, lastEndedReason, sendSignal]);
 }

--- a/examples/mobile-client/voip-call/app/src/screens/CallScreen.tsx
+++ b/examples/mobile-client/voip-call/app/src/screens/CallScreen.tsx
@@ -6,13 +6,13 @@ import { InCallView } from './InCallView';
 import { OutgoingCallView } from './OutgoingCallView';
 
 /**
- * The screen shown for the whole lifetime of a call (`status` is `connecting` or
+ * The screen shown for the whole lifetime of a call (`callStatus` is `connecting` or
  * `active`). It owns the Fishjam side of the call: mounting joins the current call's
  * room via `useCallRoom`, unmounting leaves it, and the remote peer's presence is
  * reported back to the call as connect / hang-up.
  */
 export function CallScreen() {
-  const { status, currentCall, reportConnected, endCall } = useVoIP();
+  const { callStatus, currentCall, reportConnected, endCall } = useVoIP();
   const { remotePeers } = usePeers();
 
   const joinedRoom = useCallRoom();
@@ -23,13 +23,13 @@ export function CallScreen() {
   useEffect(() => {
     if (!currentCall || joinedRoom !== currentCall.roomName) return;
 
-    if (status === 'connecting' && remotePeers.length > 0) {
+    if (callStatus === 'connecting' && remotePeers.length > 0) {
       void reportConnected();
-    } else if (status === 'active' && remotePeers.length === 0) {
+    } else if (callStatus === 'active' && remotePeers.length === 0) {
       void endCall('remote');
     }
   }, [
-    status,
+    callStatus,
     currentCall,
     joinedRoom,
     remotePeers.length,
@@ -37,7 +37,7 @@ export function CallScreen() {
     endCall,
   ]);
 
-  if (status === 'active') {
+  if (callStatus === 'active') {
     return <InCallView />;
   }
   return <OutgoingCallView />;

--- a/examples/mobile-client/voip-call/app/src/screens/UsersScreen.tsx
+++ b/examples/mobile-client/voip-call/app/src/screens/UsersScreen.tsx
@@ -19,9 +19,9 @@ import { usePlaceCall } from '../hooks/usePlaceCall';
 
 export function UsersScreen() {
   const { username, users, refreshUsers, logout } = useUser();
-  const { status } = useVoIP();
+  const { callStatus } = useVoIP();
   const placeCall = usePlaceCall();
-  const isCalling = status === 'connecting' || status === 'active';
+  const isCalling = callStatus === 'connecting' || callStatus === 'active';
 
   useEffect(() => {
     refreshUsers();

--- a/packages/mobile-client/src/voip/VoIPContext.ts
+++ b/packages/mobile-client/src/voip/VoIPContext.ts
@@ -40,10 +40,10 @@ export type CurrentCall = {
  */
 export type VoIPContextValue = {
   /** Current call lifecycle status. */
-  status: VoIPCallStatus;
+  callStatus: VoIPCallStatus;
   /** This device's VoIP push token, or `null` until APNs has issued one. */
   voipToken: string | null;
-  /** The call currently being handled, or `null` when `status` is `available`. */
+  /** The call currently being handled, or `null` when `callStatus` is `available`. */
   currentCall: CurrentCall | null;
   /**
    * Why the most recently handled call ended. `null` until a call has ended at
@@ -70,7 +70,7 @@ export type VoIPContextValue = {
   /**
    * Reports an outgoing call to `to` in `roomName` to CallKit/Core-Telecom and moves
    * to `connecting`. Run your own signaling (ringing the callee) *before* calling this.
-   * It does **not** join the room — react to `status` becoming `connecting` for that.
+   * It does **not** join the room — react to `callStatus` becoming `connecting` for that.
    */
   startCall: (to: string, roomName: string) => Promise<void>;
   /**

--- a/packages/mobile-client/src/voip/VoIPProvider.tsx
+++ b/packages/mobile-client/src/voip/VoIPProvider.tsx
@@ -35,12 +35,12 @@ export type VoIPProviderProps = PropsWithChildren & {
  * Tracks the current VoIP call state, driven by the native CallKit / Core-Telecom
  * events from {@link useVoIPEvents}, and exposes it through {@link useVoIP}.
  *
- * Joining rooms, peer tokens and media are the consumer's — react to `status` and
+ * Joining rooms, peer tokens and media are the consumer's — react to `callStatus` and
  * report back with `reportConnected` / `reportConnectFailed`.
  */
 export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children }: VoIPProviderProps) {
   const [voipToken, setVoIPToken] = useState<string | null>(null);
-  const [status, setStatus] = useState<VoIPCallStatus>('available');
+  const [callStatus, setCallStatus] = useState<VoIPCallStatus>('available');
   const [currentCall, setCurrentCall] = useState<CurrentCall | null>(null);
   const [lastEndedReason, setLastEndedReason] = useState<CallEndedReason | null>(null);
   const [isOnHold, setIsOnHold] = useState(false);
@@ -101,7 +101,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
     setIsOnHold(false);
     setIsMuted(false);
     setCurrentCall(null);
-    setStatus('available');
+    setCallStatus('available');
     setLastEndedReason(reason);
   }, []);
 
@@ -133,7 +133,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
       };
       currentCallRef.current = call;
       setCurrentCall(call);
-      setStatus('connecting');
+      setCallStatus('connecting');
       setLastEndedReason(null);
 
       try {
@@ -175,7 +175,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
       const connectedCall = { ...activeCall, startedAt: Date.now() };
       currentCallRef.current = connectedCall;
       setCurrentCall(connectedCall);
-      setStatus('active');
+      setCallStatus('active');
     } catch (err) {
       console.error('Failed to activate call:', err);
       if (currentCallRef.current === call) {
@@ -233,7 +233,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
           pendingAnswerRequestIdRef.current = null;
           isCallOnHoldRef.current = false;
           setCurrentCall(call);
-          setStatus('incoming');
+          setCallStatus('incoming');
           setLastEndedReason(null);
           setIsOnHold(false);
           setIsMuted(false);
@@ -244,7 +244,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
           if (pendingAnswer) {
             pendingWaitingAnswerRef.current = null;
             pendingAnswerRequestIdRef.current = pendingAnswer;
-            setStatus('connecting');
+            setCallStatus('connecting');
           }
         });
       },
@@ -268,7 +268,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
           }
 
           pendingAnswerRequestIdRef.current = requestId;
-          setStatus('connecting');
+          setCallStatus('connecting');
         });
       },
       [enqueueCallTransition],
@@ -312,7 +312,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
   const voipValue = useMemo(
     () => ({
       voipToken,
-      status,
+      callStatus,
       currentCall,
       lastEndedReason,
       isOnHold,
@@ -327,7 +327,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
     }),
     [
       voipToken,
-      status,
+      callStatus,
       currentCall,
       lastEndedReason,
       isOnHold,


### PR DESCRIPTION
## Description

Renames the `status` field returned from `useVoIP()` to `callStatus`.

Covers `VoIPContextValue`, `VoIPProvider`, and the `voip-call` example app.

## Motivation and Context

`status` is ambiguous next to the other `status` values a Fishjam app already
handles (`peerStatus`, permission statuses); `callStatus` names what it reports.

## Documentation impact

- [x] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
