### PR TITLE
FCE-3578: add StateStore with synchronous notifications

### DIFF
--- a/packages/tsunami/src/index.ts
+++ b/packages/tsunami/src/index.ts
@@ -9,6 +9,7 @@ export { WebDeviceManager, type WebDeviceManagerOptions } from "./devices/WebDev
 export { type ErrorRecoverability, FishjamError } from "./errors/FishjamError";
 export { ClientDisposedError } from "./errors/lifecycleErrors";
 export { FishjamClient } from "./FishjamClient";
+export { StateStore, type StateStoreOptions, type StoreListener } from "./state/StateStore";
 export * from "@fishjam-cloud/ts-client";
 
 export type MiddlewareResult = {

--- a/packages/tsunami/src/state/StateStore.test.ts
+++ b/packages/tsunami/src/state/StateStore.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
+
+import { StateStore } from "./StateStore";
+
+type TestState = {
+  counter: number;
+  label: string;
+  slice: { value: number };
+  otherSlice: { value: number };
+};
+
+const createTestStore = () =>
+  new StateStore<TestState>({
+    counter: 0,
+    label: "initial",
+    slice: { value: 1 },
+    otherSlice: { value: 2 },
+  });
+
+describe("StateStore", () => {
+  describe("snapshot stability and structural sharing", () => {
+    it("returns the same snapshot object until state actually changes", () => {
+      const store = createTestStore();
+      const snapshotBefore = store.getState();
+
+      store.update({ counter: 0, label: "initial" });
+
+      expect(store.getState()).toBe(snapshotBefore);
+    });
+
+    it("does not notify listeners for a no-op update", () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 0 });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("keeps references of slices an update did not touch", () => {
+      const store = createTestStore();
+      const untouchedSliceBefore = store.getState().otherSlice;
+
+      store.update({ slice: { value: 10 } });
+
+      expect(store.getState().otherSlice).toBe(untouchedSliceBefore);
+      expect(store.getState().slice).toEqual({ value: 10 });
+    });
+
+    it("replaces the snapshot object when a value changes", () => {
+      const store = createTestStore();
+      const snapshotBefore = store.getState();
+
+      store.update({ counter: 5 });
+
+      expect(store.getState()).not.toBe(snapshotBefore);
+      expect(store.getState().counter).toBe(5);
+    });
+  });
+
+  describe("notification timing", () => {
+    it("notifies synchronously, after the snapshot is replaced", () => {
+      const store = createTestStore();
+      let observedCounter: number | null = null;
+      store.subscribe(() => {
+        observedCounter = store.getState().counter;
+      });
+
+      store.update({ counter: 1 });
+
+      expect(observedCounter).toBe(1);
+    });
+
+    it("notifies once per effective update call", () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 1 });
+      store.update({ counter: 1 });
+      store.update({ label: "changed" });
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+
+    it("delivers one notification for a multi-slice update", () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.update({ counter: 1, label: "changed", slice: { value: 10 } });
+
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("notifies again when a listener updates the store during a notification", () => {
+      const store = createTestStore();
+      const notifiedCounters: number[] = [];
+      store.subscribe(() => {
+        const { counter } = store.getState();
+        notifiedCounters.push(counter);
+        if (counter === 1) store.update({ counter: 2 });
+      });
+
+      store.update({ counter: 1 });
+
+      expect(notifiedCounters).toEqual([1, 2]);
+    });
+
+    it("keeps notifying remaining listeners when one of them throws", () => {
+      const listenerError = new Error("listener failure");
+      const onListenerError = vi.fn();
+      const store = new StateStore<TestState>(
+        { counter: 0, label: "initial", slice: { value: 1 }, otherSlice: { value: 2 } },
+        { onListenerError },
+      );
+      const throwingListener = vi.fn(() => {
+        throw listenerError;
+      });
+      const laterListener = vi.fn();
+      store.subscribe(throwingListener);
+      store.subscribe(laterListener);
+
+      store.update({ counter: 1 });
+
+      expect(throwingListener).toHaveBeenCalledTimes(1);
+      expect(laterListener).toHaveBeenCalledTimes(1);
+      expect(onListenerError).toHaveBeenCalledWith(listenerError);
+    });
+  });
+
+  describe("subscribe", () => {
+    it("stops notifying after unsubscribe", () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      const unsubscribe = store.subscribe(listener);
+
+      unsubscribe();
+      store.update({ counter: 1 });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("does not notify anyone after clear", () => {
+      const store = createTestStore();
+      const listener = vi.fn();
+      store.subscribe(listener);
+
+      store.clear();
+      store.update({ counter: 1 });
+
+      expect(listener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("subscribeToSlice", () => {
+    it("fires with the next and previous value when the selected slice changes", () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      store.subscribeToSlice((state) => state.slice, sliceListener);
+      const previousSlice = store.getState().slice;
+
+      store.update({ slice: { value: 10 } });
+
+      expect(sliceListener).toHaveBeenCalledTimes(1);
+      expect(sliceListener).toHaveBeenCalledWith({ value: 10 }, previousSlice);
+    });
+
+    it("does not fire when only unrelated slices change", () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      store.subscribeToSlice((state) => state.slice, sliceListener);
+
+      store.update({ counter: 1, otherSlice: { value: 20 } });
+
+      expect(sliceListener).not.toHaveBeenCalled();
+    });
+
+    it("fires once per change of the selected value", () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      store.subscribeToSlice((state) => state.counter, sliceListener);
+
+      store.update({ counter: 1 });
+      store.update({ counter: 2 });
+
+      expect(sliceListener).toHaveBeenCalledTimes(2);
+      expect(sliceListener).toHaveBeenNthCalledWith(1, 1, 0);
+      expect(sliceListener).toHaveBeenNthCalledWith(2, 2, 1);
+    });
+
+    it("stops firing after unsubscribe", () => {
+      const store = createTestStore();
+      const sliceListener = vi.fn();
+      const unsubscribe = store.subscribeToSlice((state) => state.slice, sliceListener);
+
+      unsubscribe();
+      store.update({ slice: { value: 10 } });
+
+      expect(sliceListener).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("generics threading", () => {
+    it("threads the state's type parameters through the store", () => {
+      type PeerMetadata = { displayName: string };
+      type ParameterizedState<Metadata> = { localPeer: { metadata: Metadata } | null };
+
+      const store = new StateStore<ParameterizedState<PeerMetadata>>({ localPeer: null });
+      const { localPeer } = store.getState();
+
+      expectTypeOf(localPeer?.metadata).toEqualTypeOf<PeerMetadata | undefined>();
+      expect(localPeer).toBeNull();
+    });
+  });
+});

--- a/packages/tsunami/src/state/StateStore.ts
+++ b/packages/tsunami/src/state/StateStore.ts
@@ -1,0 +1,85 @@
+export type StoreListener = () => void;
+
+export type StateStoreOptions = {
+  /** Handles a listener throwing during a flush; defaults to rethrowing asynchronously. */
+  onListenerError?: (error: unknown) => void;
+};
+
+/**
+ * Observable state container. Snapshots are stable (`getState` returns the
+ * same object until a value changes) and structurally shared (an update
+ * replaces only the slices it received). Listeners are notified synchronously
+ * on every effective `update()` — write related changes as one `update()` call
+ * to get one notification; UI frameworks coalesce same-tick renders themselves.
+ */
+export class StateStore<TState extends object> {
+  private snapshot: TState;
+  private readonly listeners = new Set<StoreListener>();
+
+  public constructor(
+    initialState: TState,
+    private readonly options: StateStoreOptions = {},
+  ) {
+    this.snapshot = initialState;
+  }
+
+  public getState = (): TState => this.snapshot;
+
+  public subscribe = (listener: StoreListener): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  /** Notifies only when the selected value changes (`Object.is`). */
+  public subscribeToSlice = <Slice>(
+    selector: (state: TState) => Slice,
+    listener: (slice: Slice, previousSlice: Slice) => void,
+  ): (() => void) => {
+    let lastSeenSlice = selector(this.snapshot);
+    return this.subscribe(() => {
+      const nextSlice = selector(this.snapshot);
+      if (Object.is(nextSlice, lastSeenSlice)) return;
+      const previousSlice = lastSeenSlice;
+      lastSeenSlice = nextSlice;
+      listener(nextSlice, previousSlice);
+    });
+  };
+
+  /** Applied synchronously; a call that changes nothing keeps the snapshot and notifies nobody. */
+  public update(partial: Partial<TState>): void {
+    const keys = Object.keys(partial) as (keyof TState)[];
+    const hasChange = keys.some((key) => partial[key] !== this.snapshot[key]);
+    if (!hasChange) return;
+
+    this.snapshot = { ...this.snapshot, ...partial };
+    this.notify();
+  }
+
+  /** Drops all listeners. */
+  public clear(): void {
+    this.listeners.clear();
+  }
+
+  private notify(): void {
+    for (const listener of [...this.listeners]) {
+      try {
+        listener();
+      } catch (error) {
+        this.handleListenerError(error);
+      }
+    }
+  }
+
+  private handleListenerError(error: unknown): void {
+    if (this.options.onListenerError) {
+      this.options.onListenerError(error);
+      return;
+    }
+    // Rethrow out-of-band: the error stays observable without starving other listeners.
+    queueMicrotask(() => {
+      throw error;
+    });
+  }
+}

--- a/packages/tsunami/tsconfig.build.json
+++ b/packages/tsunami/tsconfig.build.json
@@ -1,4 +1,12 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/*.spec.ts", "src/**/*.spec.tsx"]
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx"
+  ],
+  "compilerOptions": {
+    "noEmit": false
+  }
 }

--- a/packages/tsunami/tsconfig.json
+++ b/packages/tsunami/tsconfig.json
@@ -2,7 +2,10 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "moduleResolution": "bundler",
-    "outDir": "dist/"
+    "outDir": "dist/",
+    "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": [
+    "src/**/*"
+  ]
 }


### PR DESCRIPTION
## Description

- Adds `StateStore` to `tsunami`: `getState` / `subscribe` / `subscribeToSlice`, one notification per effective `update()`, structural sharing (unchanged slices keep their references).
- Notifications are **synchronous** — this supersedes the microtask-batched version from the closed #581.
- Guards the tsunami tsconfig against source-adjacent emit (`noEmit` in base, off in build).

## Motivation and Context

The store from RFC 0015 §2–3 that the framework adapters subscribe to. Synchronous notify is required by react-client's connection specs, which assert inside synchronous `act()` — microtask batching broke them. Extracted from the validated reference on `spike/tsunami-full`.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
