### PR TITLE
FCE-3578: wire connection state into the StateStore

### DIFF
--- a/packages/tsunami/src/FishjamClient.sessionState.test.ts
+++ b/packages/tsunami/src/FishjamClient.sessionState.test.ts
@@ -1,0 +1,155 @@
+import type { Component, FishjamClient as TsClient, GenericMetadata, Peer } from "@fishjam-cloud/ts-client";
+import { EventEmitter } from "events";
+import { describe, expect, it, vi } from "vitest";
+
+import { FishjamClient } from "./FishjamClient";
+
+class FakeSignallingClient extends EventEmitter {
+  public localPeer: Peer<GenericMetadata, GenericMetadata> | null = null;
+  public remotePeers: Record<string, Peer<GenericMetadata, GenericMetadata>> = {};
+  public components: Record<string, Component> = {};
+
+  public getLocalPeer = () => this.localPeer;
+  public getRemotePeers = () => this.remotePeers;
+  public getRemoteComponents = () => this.components;
+  public connect = vi.fn(async () => {});
+  public disconnect = vi.fn();
+  public cleanup = vi.fn();
+}
+
+const createWiredClient = () => {
+  const signalling = new FakeSignallingClient();
+  const client = new FishjamClient({
+    signallingClient: signalling as unknown as TsClient<GenericMetadata, GenericMetadata>,
+  });
+  return { signalling, client };
+};
+
+const buildPeer = (id: string): Peer<GenericMetadata, GenericMetadata> => ({
+  id,
+  type: "webrtc",
+  tracks: new Map(),
+});
+
+describe("FishjamClient session state", () => {
+  it("starts idle with no participants", () => {
+    const { client } = createWiredClient();
+
+    expect(client.getState()).toMatchObject({
+      peerStatus: "idle",
+      reconnectionStatus: "idle",
+      localPeer: null,
+      remotePeers: {},
+      components: {},
+    });
+  });
+
+  it("mirrors the connection lifecycle into peerStatus", () => {
+    const { signalling, client } = createWiredClient();
+
+    signalling.emit("connectionStarted");
+    expect(client.getState().peerStatus).toBe("connecting");
+
+    signalling.emit("joined", "local-peer", [], []);
+    expect(client.getState().peerStatus).toBe("connected");
+
+    signalling.emit("disconnected");
+    expect(client.getState().peerStatus).toBe("idle");
+  });
+
+  it("sets peerStatus to error on auth, join and connection errors", () => {
+    const { signalling, client } = createWiredClient();
+
+    for (const errorEvent of ["authError", "joinError", "connectionError"] as const) {
+      signalling.emit("disconnected");
+      signalling.emit(errorEvent);
+      expect(client.getState().peerStatus).toBe("error");
+    }
+  });
+
+  it("tracks reconnectionStatus across the reconnect lifecycle", () => {
+    const { signalling, client } = createWiredClient();
+
+    signalling.emit("reconnectionStarted");
+    expect(client.getState().reconnectionStatus).toBe("reconnecting");
+
+    signalling.emit("reconnected");
+    expect(client.getState().reconnectionStatus).toBe("idle");
+
+    signalling.emit("reconnectionStarted");
+    signalling.emit("reconnectionRetriesLimitReached");
+    expect(client.getState().reconnectionStatus).toBe("error");
+  });
+
+  it("promotes auth and join errors to reconnection errors only while reconnecting", () => {
+    const { signalling, client } = createWiredClient();
+
+    signalling.emit("joinError");
+    expect(client.getState().reconnectionStatus).toBe("idle");
+
+    signalling.emit("reconnectionStarted");
+    signalling.emit("authError");
+    expect(client.getState().reconnectionStatus).toBe("error");
+  });
+
+  it("re-reads participants from the signalling client on participant events", () => {
+    const { signalling, client } = createWiredClient();
+
+    signalling.localPeer = buildPeer("local");
+    signalling.remotePeers = { remote: buildPeer("remote") };
+    signalling.emit("peerJoined", signalling.remotePeers["remote"]);
+
+    expect(client.getState().localPeer?.id).toBe("local");
+    expect(Object.keys(client.getState().remotePeers)).toEqual(["remote"]);
+  });
+
+  it("produces fresh participant references even when the signalling client mutates in place", () => {
+    const { signalling, client } = createWiredClient();
+    signalling.localPeer = buildPeer("local");
+    signalling.emit("peerJoined", buildPeer("remote"));
+    const localPeerBefore = client.getState().localPeer;
+
+    // The signalling client mutates the same peer object; the mirror must
+    // still expose the change as a new reference.
+    signalling.emit("localTrackAdded");
+
+    expect(client.getState().localPeer).not.toBe(localPeerBefore);
+  });
+
+  it("notifies subscribers synchronously on state changes", () => {
+    const { signalling, client } = createWiredClient();
+    const observedStatuses: string[] = [];
+    client.subscribe(() => {
+      observedStatuses.push(client.getState().peerStatus);
+    });
+
+    signalling.emit("connectionStarted");
+    signalling.emit("joined", "local-peer", [], []);
+
+    expect(observedStatuses).toEqual(["connecting", "connected"]);
+  });
+
+  it("supports slice subscriptions on the client", () => {
+    const { signalling, client } = createWiredClient();
+    const sliceListener = vi.fn();
+    client.subscribeToSlice((state) => state.peerStatus, sliceListener);
+
+    signalling.emit("connectionStarted");
+    signalling.emit("reconnectionStarted");
+
+    expect(sliceListener).toHaveBeenCalledTimes(1);
+    expect(sliceListener).toHaveBeenCalledWith("connecting", "idle");
+  });
+
+  it("stops mirroring after dispose", () => {
+    const { signalling, client } = createWiredClient();
+    const listener = vi.fn();
+    client.subscribe(listener);
+
+    client.dispose();
+    signalling.emit("connectionStarted");
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(client.getState().peerStatus).toBe("idle");
+  });
+});

--- a/packages/tsunami/src/FishjamClient.ts
+++ b/packages/tsunami/src/FishjamClient.ts
@@ -99,7 +99,10 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
 
     // An injected signalling client can emit events before any client method
     // is called, so its event forwarding must be wired immediately.
-    if (signallingClient) this.adoptTsClient(signallingClient);
+    if (signallingClient) {
+      this.tsClient = signallingClient;
+      this.wireTsClient(signallingClient);
+    }
   }
 
   /** Synchronously readable snapshot of the client's observable state. */
@@ -333,11 +336,15 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
 
   private ensureTsClient(): TsClient<PeerMetadata, ServerMetadata> {
     this.resources.assertActive();
-    return this.tsClient ?? this.adoptTsClient(new TsClient<PeerMetadata, ServerMetadata>(this.config));
+    if (this.tsClient) return this.tsClient;
+
+    const tsClient = new TsClient<PeerMetadata, ServerMetadata>(this.config);
+    this.tsClient = tsClient;
+    this.wireTsClient(tsClient);
+    return tsClient;
   }
 
-  /** Takes ownership of a signalling client and forwards its events to this wrapper. */
-  private adoptTsClient(tsClient: TsClient<PeerMetadata, ServerMetadata>): TsClient<PeerMetadata, ServerMetadata> {
+  private wireTsClient(tsClient: TsClient<PeerMetadata, ServerMetadata>): void {
     const emitter = tsClient as EventEmitter;
     const emit = emitter.emit.bind(emitter);
     emitter.emit = (event: string | symbol, ...args: unknown[]) => {
@@ -345,9 +352,6 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
       const handledByTsunami = EventEmitter.prototype.emit.call(this, event, ...args);
       return handledByTsClient || handledByTsunami;
     };
-
-    this.tsClient = tsClient;
-    return tsClient;
   }
 
   private teardownTsClient(tsClient: TsClient<PeerMetadata, ServerMetadata>): void {

--- a/packages/tsunami/src/FishjamClient.ts
+++ b/packages/tsunami/src/FishjamClient.ts
@@ -19,11 +19,55 @@ import { EventEmitter } from "events";
 import type TypedEmitter from "typed-emitter";
 
 import { ClientResourceScope } from "./ClientResourceScope";
+import { type ClientState, createInitialClientState } from "./state/clientState";
+import { StateStore, type StoreListener } from "./state/StateStore";
 
 type LegacyClientInternals<PeerMetadata> = {
   reconnectManager?: { reset(metadata: PeerMetadata): void };
   sendStatisticsInterval?: ReturnType<typeof setInterval>;
 };
+
+export type FishjamClientConfig<PeerMetadata = GenericMetadata, ServerMetadata = GenericMetadata> = CreateConfig & {
+  /**
+   * Strangler-migration hook: use an externally created signalling client
+   * instead of constructing one. Also the seam tests inject fakes through.
+   *
+   * @internal
+   */
+  signallingClient?: TsClient<PeerMetadata, ServerMetadata>;
+};
+
+/**
+ * Events after which only the participant slices of {@link ClientState} are
+ * re-read. Events that also change connection status (`joined`,
+ * `disconnected`, `reconnected`) are handled separately so each event
+ * produces a single state update.
+ */
+const participantEventNames = [
+  "authSuccess",
+  "trackReady",
+  "trackAdded",
+  "trackRemoved",
+  "trackUpdated",
+  "encodingChanged",
+  "peerJoined",
+  "peerLeft",
+  "peerUpdated",
+  "componentAdded",
+  "componentRemoved",
+  "componentUpdated",
+  "localTrackAdded",
+  "localTrackRemoved",
+  "localTrackReplaced",
+  "localTrackMuted",
+  "localTrackUnmuted",
+  "localTrackBandwidthSet",
+  "localTrackEncodingBandwidthSet",
+  "localTrackEncodingEnabled",
+  "localTrackEncodingDisabled",
+  "localPeerMetadataChanged",
+  "localTrackMetadataChanged",
+] as const;
 
 /**
  * Framework-agnostic Fishjam SDK client.
@@ -41,11 +85,36 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
   private readonly resources = new ClientResourceScope();
 
   private tsClient: TsClient<PeerMetadata, ServerMetadata> | null = null;
+  private readonly injectedTsClient: TsClient<PeerMetadata, ServerMetadata> | null = null;
 
-  public constructor(config?: CreateConfig) {
+  private readonly store = new StateStore<ClientState<PeerMetadata, ServerMetadata>>(
+    createInitialClientState<PeerMetadata, ServerMetadata>(),
+  );
+
+  public constructor(config?: FishjamClientConfig<PeerMetadata, ServerMetadata>) {
     super();
-    this.config = config;
+    const { signallingClient, ...createConfig } = config ?? {};
+    this.config = createConfig;
+    this.injectedTsClient = signallingClient ?? null;
+
+    this.bindSessionStateEvents();
+
+    // An injected signalling client can emit events before any client method
+    // is called, so its event forwarding must be wired immediately.
+    if (signallingClient) this.getTsClient();
   }
+
+  /** Synchronously readable snapshot of the client's observable state. */
+  public getState = (): ClientState<PeerMetadata, ServerMetadata> => this.store.getState();
+
+  /** Notifies on every state change; returns an unsubscribe function. */
+  public subscribe = (listener: StoreListener): (() => void) => this.store.subscribe(listener);
+
+  /** Notifies only when the selected part of the state changes (`Object.is`). */
+  public subscribeToSlice = <Slice>(
+    selector: (state: ClientState<PeerMetadata, ServerMetadata>) => Slice,
+    listener: (slice: Slice, previousSlice: Slice) => void,
+  ): (() => void) => this.store.subscribeToSlice(selector, listener);
 
   public get isDisposed(): boolean {
     return this.resources.isDisposed;
@@ -56,11 +125,11 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     return this.tsClient?.status ?? "new";
   }
 
-  public emit<Event extends keyof MessageEvents<PeerMetadata, ServerMetadata>>(
+  public override emit<Event extends keyof MessageEvents<PeerMetadata, ServerMetadata>>(
     event: Event,
     ...args: Parameters<MessageEvents<PeerMetadata, ServerMetadata>[Event]>
   ): boolean;
-  public emit(event: string | symbol, ...args: unknown[]): boolean {
+  public override emit(event: string | symbol, ...args: unknown[]): boolean {
     if (this.tsClient) return (this.tsClient as EventEmitter).emit(event, ...args);
     return EventEmitter.prototype.emit.call(this, event, ...args);
   }
@@ -206,6 +275,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     if (this.resources.isDisposed) return;
 
     this.resources.dispose();
+    this.store.clear();
 
     const tsClient = this.tsClient;
     if (tsClient) {
@@ -226,11 +296,48 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     this.tsClient?.cleanup();
   }
 
+  private bindSessionStateEvents(): void {
+    type StatePartial = Partial<ClientState<PeerMetadata, ServerMetadata>>;
+
+    // Fresh references on every refresh: the signalling client mutates peers
+    // in place, so re-read values must not be reference-equal to the previous
+    // slice or the store would treat them as unchanged.
+    const participants = (): StatePartial => {
+      const localPeer = this.getLocalPeer();
+      return {
+        localPeer: localPeer === null ? null : { ...localPeer },
+        remotePeers: { ...this.getRemotePeers() },
+        components: { ...this.getRemoteComponents() },
+      };
+    };
+    const reconnectionErrorIfReconnecting = (): StatePartial =>
+      this.store.getState().reconnectionStatus === "reconnecting" ? { reconnectionStatus: "error" } : {};
+
+    // Each event composes everything it affects into ONE update, so
+    // subscribers observe exactly one notification per event.
+    this.on("connectionStarted", () => this.store.update({ peerStatus: "connecting" }));
+    this.on("joined", () => this.store.update({ peerStatus: "connected", ...participants() }));
+    this.on("reconnected", () =>
+      this.store.update({ peerStatus: "connected", reconnectionStatus: "idle", ...participants() }),
+    );
+    this.on("disconnected", () => this.store.update({ peerStatus: "idle", ...participants() }));
+    this.on("authError", () => this.store.update({ peerStatus: "error", ...reconnectionErrorIfReconnecting() }));
+    this.on("joinError", () => this.store.update({ peerStatus: "error", ...reconnectionErrorIfReconnecting() }));
+    this.on("connectionError", () => this.store.update({ peerStatus: "error" }));
+    this.on("reconnectionStarted", () => this.store.update({ reconnectionStatus: "reconnecting" }));
+    this.on("reconnectionRetriesLimitReached", () => this.store.update({ reconnectionStatus: "error" }));
+
+    const refreshParticipants = () => this.store.update(participants());
+    for (const eventName of participantEventNames) {
+      this.on(eventName, refreshParticipants);
+    }
+  }
+
   private getTsClient(): TsClient<PeerMetadata, ServerMetadata> {
     this.resources.assertActive();
     if (this.tsClient) return this.tsClient;
 
-    const tsClient = new TsClient<PeerMetadata, ServerMetadata>(this.config);
+    const tsClient = this.injectedTsClient ?? new TsClient<PeerMetadata, ServerMetadata>(this.config);
     const emitter = tsClient as EventEmitter;
     const emit = emitter.emit.bind(emitter);
     emitter.emit = (event: string | symbol, ...args: unknown[]) => {

--- a/packages/tsunami/src/FishjamClient.ts
+++ b/packages/tsunami/src/FishjamClient.ts
@@ -85,7 +85,6 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
   private readonly resources = new ClientResourceScope();
 
   private tsClient: TsClient<PeerMetadata, ServerMetadata> | null = null;
-  private readonly injectedTsClient: TsClient<PeerMetadata, ServerMetadata> | null = null;
 
   private readonly store = new StateStore<ClientState<PeerMetadata, ServerMetadata>>(
     createInitialClientState<PeerMetadata, ServerMetadata>(),
@@ -95,13 +94,12 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     super();
     const { signallingClient, ...createConfig } = config ?? {};
     this.config = createConfig;
-    this.injectedTsClient = signallingClient ?? null;
 
     this.bindSessionStateEvents();
 
     // An injected signalling client can emit events before any client method
     // is called, so its event forwarding must be wired immediately.
-    if (signallingClient) this.getTsClient();
+    if (signallingClient) this.adoptTsClient(signallingClient);
   }
 
   /** Synchronously readable snapshot of the client's observable state. */
@@ -136,7 +134,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
 
   public async connect(config: ConnectConfig<PeerMetadata>): Promise<void> {
     return this.resources.run(() => {
-      const tsClient = this.getTsClient();
+      const tsClient = this.ensureTsClient();
 
       try {
         return tsClient.connect(config);
@@ -181,46 +179,46 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     simulcastConfig?: SimulcastConfig,
     maxBandwidth?: TrackBandwidthLimit,
   ): Promise<string> {
-    return this.resources.run(() => this.getTsClient().addTrack(track, trackMetadata, simulcastConfig, maxBandwidth));
+    return this.resources.run(() => this.ensureTsClient().addTrack(track, trackMetadata, simulcastConfig, maxBandwidth));
   }
 
   public async replaceTrack(trackId: string, newTrack: MediaStreamTrack | null): Promise<void> {
-    return this.resources.run(() => this.getTsClient().replaceTrack(trackId, newTrack));
+    return this.resources.run(() => this.ensureTsClient().replaceTrack(trackId, newTrack));
   }
 
   public async setTrackBandwidth(trackId: string, bandwidth: BandwidthLimit): Promise<boolean> {
-    return this.resources.run(() => this.getTsClient().setTrackBandwidth(trackId, bandwidth));
+    return this.resources.run(() => this.ensureTsClient().setTrackBandwidth(trackId, bandwidth));
   }
 
   public async setEncodingBandwidth(trackId: string, rid: Variant, bandwidth: BandwidthLimit): Promise<boolean> {
-    return this.resources.run(() => this.getTsClient().setEncodingBandwidth(trackId, rid, bandwidth));
+    return this.resources.run(() => this.ensureTsClient().setEncodingBandwidth(trackId, rid, bandwidth));
   }
 
   public removeTrack(trackId: string): Promise<void> {
-    return this.resources.run(() => this.getTsClient().removeTrack(trackId));
+    return this.resources.run(() => this.ensureTsClient().removeTrack(trackId));
   }
 
   public setTargetTrackEncoding(trackId: string, encoding: Variant): void {
     this.resources.assertActive();
-    this.getTsClient().setTargetTrackEncoding(trackId, encoding);
+    this.ensureTsClient().setTargetTrackEncoding(trackId, encoding);
   }
 
   public enableTrackEncoding(trackId: string, encoding: Variant): Promise<void> {
-    return this.resources.run(() => this.getTsClient().enableTrackEncoding(trackId, encoding));
+    return this.resources.run(() => this.ensureTsClient().enableTrackEncoding(trackId, encoding));
   }
 
   public disableTrackEncoding(trackId: string, encoding: Variant): Promise<void> {
-    return this.resources.run(() => this.getTsClient().disableTrackEncoding(trackId, encoding));
+    return this.resources.run(() => this.ensureTsClient().disableTrackEncoding(trackId, encoding));
   }
 
   public updatePeerMetadata = (peerMetadata: PeerMetadata): void => {
     this.resources.assertActive();
-    this.getTsClient().updatePeerMetadata(peerMetadata);
+    this.ensureTsClient().updatePeerMetadata(peerMetadata);
   };
 
   public updateTrackMetadata = (trackId: string, trackMetadata: TrackMetadata): void => {
     this.resources.assertActive();
-    this.getTsClient().updateTrackMetadata(trackId, trackMetadata);
+    this.ensureTsClient().updateTrackMetadata(trackId, trackMetadata);
   };
 
   public isReconnecting(): boolean {
@@ -233,22 +231,22 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
 
   public leave = (): void => {
     this.resources.assertActive();
-    this.getTsClient().leave();
+    this.ensureTsClient().leave();
   };
 
   public createDataChannels(): Promise<void> {
-    return this.resources.run(() => this.getTsClient().createDataChannels());
+    return this.resources.run(() => this.ensureTsClient().createDataChannels());
   }
 
   public publishData(data: Uint8Array, options: DataChannelOptions): void {
     this.resources.assertActive();
-    this.getTsClient().publishData(data, options);
+    this.ensureTsClient().publishData(data, options);
   }
 
   public subscribeData(callback: DataCallback, options: DataChannelOptions): () => void {
     this.resources.assertActive();
 
-    const unsubscribe = this.getTsClient().subscribeData(callback, options);
+    const unsubscribe = this.ensureTsClient().subscribeData(callback, options);
     let subscribed = true;
     const cleanup = () => {
       if (!subscribed) return;
@@ -333,11 +331,13 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     }
   }
 
-  private getTsClient(): TsClient<PeerMetadata, ServerMetadata> {
+  private ensureTsClient(): TsClient<PeerMetadata, ServerMetadata> {
     this.resources.assertActive();
-    if (this.tsClient) return this.tsClient;
+    return this.tsClient ?? this.adoptTsClient(new TsClient<PeerMetadata, ServerMetadata>(this.config));
+  }
 
-    const tsClient = this.injectedTsClient ?? new TsClient<PeerMetadata, ServerMetadata>(this.config);
+  /** Takes ownership of a signalling client and forwards its events to this wrapper. */
+  private adoptTsClient(tsClient: TsClient<PeerMetadata, ServerMetadata>): TsClient<PeerMetadata, ServerMetadata> {
     const emitter = tsClient as EventEmitter;
     const emit = emitter.emit.bind(emitter);
     emitter.emit = (event: string | symbol, ...args: unknown[]) => {

--- a/packages/tsunami/src/index.ts
+++ b/packages/tsunami/src/index.ts
@@ -8,7 +8,8 @@ export { LocalStorageDevicePersistence } from "./devices/LocalStorageDevicePersi
 export { WebDeviceManager, type WebDeviceManagerOptions } from "./devices/WebDeviceManager";
 export { type ErrorRecoverability, FishjamError } from "./errors/FishjamError";
 export { ClientDisposedError } from "./errors/lifecycleErrors";
-export { FishjamClient } from "./FishjamClient";
+export { FishjamClient, type FishjamClientConfig } from "./FishjamClient";
+export { type ClientState, createInitialClientState, type PeerStatus } from "./state/clientState";
 export { StateStore, type StateStoreOptions, type StoreListener } from "./state/StateStore";
 export * from "@fishjam-cloud/ts-client";
 

--- a/packages/tsunami/src/state/clientState.ts
+++ b/packages/tsunami/src/state/clientState.ts
@@ -1,0 +1,39 @@
+import type { Component, GenericMetadata, Peer, ReconnectionStatus } from "@fishjam-cloud/ts-client";
+
+/**
+ * Represents the possible statuses of a peer connection.
+ *
+ * - `idle` - Peer is not connected, either never connected or successfully disconnected.
+ * - `connecting` - Peer is in the process of connecting.
+ * - `connected` - Peer has successfully connected.
+ * - `error` - There was an error in the connection process.
+ */
+export type PeerStatus = "connecting" | "connected" | "error" | "idle";
+
+/**
+ * Flat, synchronously readable snapshot of the client's observable state.
+ *
+ * Snapshots use structural sharing: an update replaces only the slices it
+ * touched, so consumers can detect unchanged slices by reference equality.
+ */
+export interface ClientState<PeerMetadata = GenericMetadata, ServerMetadata = GenericMetadata> {
+  // connection
+  peerStatus: PeerStatus;
+  reconnectionStatus: ReconnectionStatus;
+
+  // participants
+  localPeer: Peer<PeerMetadata, ServerMetadata> | null;
+  remotePeers: Record<string, Peer<PeerMetadata, ServerMetadata>>;
+  components: Record<string, Component>;
+}
+
+export const createInitialClientState = <PeerMetadata, ServerMetadata>(): ClientState<
+  PeerMetadata,
+  ServerMetadata
+> => ({
+  peerStatus: "idle",
+  reconnectionStatus: "idle",
+  localPeer: null,
+  remotePeers: {},
+  components: {},
+});


### PR DESCRIPTION
Stacked on #585.

## Description

- `ClientState` gets its connection slices: `peerStatus`, `reconnectionStatus`, `localPeer`, `remotePeers`, `components`.
- The `FishjamClient` wrapper mirrors session state into the `StateStore`: each signalling event composes everything it affects into **one** store update; participant slices are re-read with fresh references (ts-client mutates peers in place).
- `signallingClient` injection seam (`@internal`), adopted eagerly so injected fakes can emit before any method call — the seam the react-client suite drives.
- Public surface: `getState` / `subscribe` / `subscribeToSlice`; `dispose()` clears the store.

## Motivation and Context

Framework adapters (react-client next in the stack) need a subscribable, synchronously readable snapshot instead of hand-tracking signalling events. One-event-one-update keeps re-render counts sane.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
