### PR TITLE
FCE-3589: react-client connection hooks read the tsunami store

### DIFF
--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -66,6 +66,7 @@
   },
   "dependencies": {
     "@fishjam-cloud/ts-client": "workspace:*",
+    "@fishjam-cloud/tsunami": "workspace:*",
     "events": "3.3.0",
     "lodash.isequal": "4.5.0"
   },

--- a/packages/react-client/src/FishjamProvider.tsx
+++ b/packages/react-client/src/FishjamProvider.tsx
@@ -1,5 +1,6 @@
-import { FishjamClient, getLogger, type ReconnectConfig } from "@fishjam-cloud/ts-client";
-import { type PropsWithChildren, useMemo, useRef } from "react";
+import { type FishjamClient, getLogger, type ReconnectConfig } from "@fishjam-cloud/ts-client";
+import { FishjamClient as TsunamiClient } from "@fishjam-cloud/tsunami";
+import { type PropsWithChildren, type RefObject, useMemo, useRef } from "react";
 
 import { CameraContext } from "./contexts/camera";
 import { CustomSourceContext } from "./contexts/customSource";
@@ -72,9 +73,15 @@ export interface FishjamProviderProps extends PropsWithChildren {
  * @category Components
  */
 export function FishjamProvider(props: FishjamProviderProps) {
-  const fishjamClientRef = useRef(
-    props.fishjamClient ?? new FishjamClient({ reconnect: props.reconnect, debug: props.debug }),
-  );
+  const fishjamClientRef = useRef<TsunamiClient | null>(null);
+  if (fishjamClientRef.current === null) {
+    fishjamClientRef.current = new TsunamiClient({
+      reconnect: props.reconnect,
+      debug: props.debug,
+      signallingClient: props.fishjamClient,
+    });
+  }
+  const client = fishjamClientRef.current;
 
   const persistHandlers = useMemo(() => {
     if (props.persistLastDevice === false) return undefined;
@@ -93,7 +100,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
     logger,
   });
 
-  const peerStatus = usePeerStatus(fishjamClientRef.current);
+  const peerStatus = usePeerStatus(client);
 
   const mergedBandwidthLimits = useMemo(
     () => mergeWithDefaultBandwitdthLimits(props.bandwidthLimits),
@@ -101,7 +108,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
   );
 
   const audioTrackManager = useTrackManager({
-    tsClient: fishjamClientRef.current,
+    tsClient: client,
     peerStatus,
     deviceManager: microphoneManager,
     bandwidthLimits: mergedBandwidthLimits,
@@ -111,7 +118,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
   });
 
   const videoTrackManager = useTrackManager({
-    tsClient: fishjamClientRef.current,
+    tsClient: client,
     peerStatus,
     deviceManager: cameraManager,
     bandwidthLimits: mergedBandwidthLimits,
@@ -121,7 +128,7 @@ export function FishjamProvider(props: FishjamProviderProps) {
   });
 
   const screenShareManager = useScreenShareManager({
-    fishjamClient: fishjamClientRef.current,
+    fishjamClient: client,
     peerStatus,
     logger,
   });
@@ -133,15 +140,15 @@ export function FishjamProvider(props: FishjamProviderProps) {
   );
 
   const customSourceManager = useCustomSourceManager({
-    fishjamClient: fishjamClientRef.current,
+    fishjamClient: client,
     peerStatus,
     logger,
   });
 
-  const fishjamClientState = useFishjamClientState(fishjamClientRef.current);
+  const fishjamClientState = useFishjamClientState(client);
 
   return (
-    <FishjamClientContext.Provider value={fishjamClientRef}>
+    <FishjamClientContext.Provider value={fishjamClientRef as RefObject<TsunamiClient>}>
       <FishjamClientStateContext.Provider value={fishjamClientState}>
         <FishjamIdContext.Provider value={props.fishjamId}>
           <InitDevicesContext.Provider value={initializeDevices}>

--- a/packages/react-client/src/contexts/fishjamClient.ts
+++ b/packages/react-client/src/contexts/fishjamClient.ts
@@ -1,4 +1,4 @@
-import type { FishjamClient } from "@fishjam-cloud/ts-client";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
 import { createContext, type RefObject } from "react";
 
 export const FishjamClientContext = createContext<RefObject<FishjamClient> | null>(null);

--- a/packages/react-client/src/hooks/internal/useCustomSourceManager.ts
+++ b/packages/react-client/src/hooks/internal/useCustomSourceManager.ts
@@ -1,4 +1,5 @@
-import { type FishjamClient, type Logger, type TrackMetadata, TrackTypeError } from "@fishjam-cloud/ts-client";
+import { type Logger, type TrackMetadata, TrackTypeError } from "@fishjam-cloud/ts-client";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import type { CustomSourceState, CustomSourceTracks } from "../../types/internal";

--- a/packages/react-client/src/hooks/internal/useFishjamClientState.ts
+++ b/packages/react-client/src/hooks/internal/useFishjamClientState.ts
@@ -1,49 +1,9 @@
-import type { Component, FishjamClient, GenericMetadata, MessageEvents } from "@fishjam-cloud/ts-client";
-import { useCallback, useMemo, useRef, useSyncExternalStore } from "react";
+import type { Component, GenericMetadata } from "@fishjam-cloud/ts-client";
+import type { ClientState, FishjamClient } from "@fishjam-cloud/tsunami";
+import { useCallback, useRef, useSyncExternalStore } from "react";
 
 import type { BrandedPeer } from "../../types/internal";
 import type { PeerId } from "../../types/public";
-
-const eventNames = [
-  "socketClose",
-  "socketError",
-  "socketOpen",
-  "authSuccess",
-  "authError",
-  "disconnected",
-  "reconnectionStarted",
-  "reconnected",
-  "reconnectionRetriesLimitReached",
-  "joined",
-  "joinError",
-  "trackReady",
-  "trackAdded",
-  "trackRemoved",
-  "trackUpdated",
-  "encodingChanged",
-  "peerJoined",
-  "peerLeft",
-  "peerUpdated",
-  "componentAdded",
-  "componentRemoved",
-  "componentUpdated",
-  "connectionError",
-  "tracksPriorityChanged",
-  "bandwidthEstimationChanged",
-  "targetTrackEncodingRequested",
-  "localTrackAdded",
-  "localTrackRemoved",
-  "localTrackReplaced",
-  "localTrackMuted",
-  "localTrackUnmuted",
-  "localTrackBandwidthSet",
-  "localTrackEncodingBandwidthSet",
-  "localTrackEncodingEnabled",
-  "localTrackEncodingDisabled",
-  "localPeerMetadataChanged",
-  "localTrackMetadataChanged",
-  "disconnectRequested",
-] as const satisfies (keyof MessageEvents<unknown, unknown>)[];
 
 export interface FishjamClientState<P = GenericMetadata, S = GenericMetadata> {
   peers: Record<PeerId, BrandedPeer<P, S>>;
@@ -57,43 +17,24 @@ This is an internally used hook.
 It is not meant to be used by the end user.
 */
 export function useFishjamClientState<P, S>(fishjamClient: FishjamClient<P, S>): FishjamClientState<P, S> {
-  const client = useMemo(() => fishjamClient, [fishjamClient]);
-  const mutationRef = useRef(false);
-
-  const subscribe = useCallback(
-    (subscribeCallback: () => void) => {
-      const callback = () => {
-        mutationRef.current = true;
-        subscribeCallback();
-      };
-      eventNames.forEach((eventName) => client.on(eventName, callback));
-      return () => {
-        eventNames.forEach((eventName) => client.removeListener(eventName, callback));
-      };
-    },
-    [client],
-  );
-
-  const lastSnapshotRef = useRef<FishjamClientState<P, S> | null>(null);
+  const lastSnapshotRef = useRef<{ source: ClientState<P, S>; value: FishjamClientState<P, S> } | null>(null);
 
   const getSnapshot: () => FishjamClientState<P, S> = useCallback(() => {
-    if (mutationRef.current || lastSnapshotRef.current === null) {
-      const peers = client.getRemotePeers();
-      const components = client.getRemoteComponents();
-      const localPeer = client.getLocalPeer();
-      const isReconnecting = client.isReconnecting();
-
+    const source = fishjamClient.getState();
+    if (lastSnapshotRef.current?.source !== source) {
       lastSnapshotRef.current = {
-        peers: peers as Record<PeerId, BrandedPeer<P, S>>,
-        components,
-        localPeer: localPeer as BrandedPeer<P, S>,
-        isReconnecting,
+        source,
+        value: {
+          peers: source.remotePeers as Record<PeerId, BrandedPeer<P, S>>,
+          components: source.components,
+          localPeer: source.localPeer as BrandedPeer<P, S> | null,
+          isReconnecting: source.reconnectionStatus === "reconnecting",
+        },
       };
-      mutationRef.current = false;
     }
 
-    return lastSnapshotRef.current;
-  }, [client]);
+    return lastSnapshotRef.current.value;
+  }, [fishjamClient]);
 
-  return useSyncExternalStore(subscribe, getSnapshot);
+  return useSyncExternalStore(fishjamClient.subscribe, getSnapshot);
 }

--- a/packages/react-client/src/hooks/internal/usePeerStatus.ts
+++ b/packages/react-client/src/hooks/internal/usePeerStatus.ts
@@ -1,43 +1,10 @@
-import type { FishjamClient } from "@fishjam-cloud/ts-client";
-import { useEffect, useState } from "react";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
+import { useCallback, useSyncExternalStore } from "react";
 
 import type { PeerStatus } from "../../types/public";
 
-export const usePeerStatus = (client: FishjamClient) => {
-  const [peerStatus, setPeerStatus] = useState<PeerStatus>("idle");
-
-  useEffect(() => {
-    const setConnecting = () => {
-      setPeerStatus("connecting");
-    };
-    const setError = () => {
-      setPeerStatus("error");
-    };
-    const setJoined = () => {
-      setPeerStatus("connected");
-    };
-    const setDisconnected = () => {
-      setPeerStatus("idle");
-    };
-
-    client.on("connectionStarted", setConnecting);
-    client.on("reconnected", setJoined);
-    client.on("joined", setJoined);
-    client.on("authError", setError);
-    client.on("joinError", setError);
-    client.on("connectionError", setError);
-    client.on("disconnected", setDisconnected);
-
-    return () => {
-      client.off("connectionStarted", setConnecting);
-      client.off("reconnected", setJoined);
-      client.off("joined", setJoined);
-      client.off("authError", setError);
-      client.off("joinError", setError);
-      client.off("connectionError", setError);
-      client.off("disconnected", setDisconnected);
-    };
-  }, [client, setPeerStatus]);
-
-  return peerStatus;
-};
+export const usePeerStatus = (client: FishjamClient): PeerStatus =>
+  useSyncExternalStore(
+    client.subscribe,
+    useCallback(() => client.getState().peerStatus, [client]),
+  );

--- a/packages/react-client/src/hooks/internal/useReconnection.ts
+++ b/packages/react-client/src/hooks/internal/useReconnection.ts
@@ -1,5 +1,5 @@
 import type { ReconnectionStatus } from "@fishjam-cloud/ts-client";
-import { useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useSyncExternalStore } from "react";
 
 import { FishjamClientContext } from "../../contexts/fishjamClient";
 
@@ -11,38 +11,10 @@ export const useReconnection = (): ReconnectionStatus => {
   const fishjamClientRef = useContext(FishjamClientContext);
   if (!fishjamClientRef) throw Error("useConnection must be used within FishjamProvider");
 
-  const [reconnectionStatus, setReconnectionStatus] = useState<ReconnectionStatus>("idle");
+  const client = fishjamClientRef.current;
 
-  useEffect(() => {
-    const client = fishjamClientRef.current;
-
-    const setReconnecting = () => {
-      setReconnectionStatus("reconnecting");
-    };
-    const setIdle = () => {
-      setReconnectionStatus("idle");
-    };
-    const setError = () => {
-      setReconnectionStatus("error");
-    };
-    const setErrorIfReconnecting = () => {
-      setReconnectionStatus((prev) => (prev === "reconnecting" ? "error" : prev));
-    };
-
-    client.on("reconnectionStarted", setReconnecting);
-    client.on("reconnected", setIdle);
-    client.on("reconnectionRetriesLimitReached", setError);
-    client.on("authError", setErrorIfReconnecting);
-    client.on("joinError", setErrorIfReconnecting);
-
-    return () => {
-      client.off("reconnectionStarted", setReconnecting);
-      client.off("reconnected", setIdle);
-      client.off("reconnectionRetriesLimitReached", setError);
-      client.off("authError", setErrorIfReconnecting);
-      client.off("joinError", setErrorIfReconnecting);
-    };
-  }, [fishjamClientRef]);
-
-  return reconnectionStatus;
+  return useSyncExternalStore(
+    client.subscribe,
+    useCallback(() => client.getState().reconnectionStatus, [client]),
+  );
 };

--- a/packages/react-client/src/hooks/internal/useScreenshareManager.ts
+++ b/packages/react-client/src/hooks/internal/useScreenshareManager.ts
@@ -1,4 +1,5 @@
-import { type FishjamClient, type Logger, type TrackMetadata, TrackTypeError } from "@fishjam-cloud/ts-client";
+import { type Logger, type TrackMetadata, TrackTypeError } from "@fishjam-cloud/ts-client";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import type { ScreenShareState } from "../../types/internal";
@@ -70,7 +71,9 @@ export const useScreenShareManager = ({
   const addTrackToFishjamClient = useCallback(
     async (track: MediaStreamTrack, trackMetadata: TrackMetadata) => {
       try {
-        return fishjamClient.addTrack(track, trackMetadata);
+        // Awaited so a rejected addTrack (the core surfaces publish failures as
+        // rejections) lands in this catch and keeps the local track alive.
+        return await fishjamClient.addTrack(track, trackMetadata);
       } catch (err) {
         if (err instanceof TrackTypeError) {
           logger.warn(err.message);

--- a/packages/react-client/src/hooks/internal/useTrackManager.ts
+++ b/packages/react-client/src/hooks/internal/useTrackManager.ts
@@ -1,4 +1,5 @@
-import { type FishjamClient, type Logger, type TrackMetadata, TrackTypeError, Variant } from "@fishjam-cloud/ts-client";
+import { type Logger, type TrackMetadata, TrackTypeError, Variant } from "@fishjam-cloud/ts-client";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
 import { useEffect, useRef } from "react";
 
 import type { TrackManager } from "../../types/internal";

--- a/packages/react-client/src/hooks/usePeers.ts
+++ b/packages/react-client/src/hooks/usePeers.ts
@@ -1,12 +1,5 @@
-import type {
-  EncodingReason,
-  FishjamClient,
-  Metadata,
-  Peer,
-  SimulcastConfig,
-  TrackMetadata,
-  Variant,
-} from "@fishjam-cloud/ts-client";
+import type { EncodingReason, Metadata, Peer, SimulcastConfig, TrackMetadata, Variant } from "@fishjam-cloud/ts-client";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
 import { useCallback, useContext } from "react";
 
 import { FishjamClientContext } from "../contexts/fishjamClient";

--- a/packages/react-client/src/utils/track.ts
+++ b/packages/react-client/src/utils/track.ts
@@ -1,5 +1,6 @@
-import type { FishjamClient, SimulcastConfig, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
+import type { SimulcastConfig, TrackContext, TrackMetadata } from "@fishjam-cloud/ts-client";
 import { Variant } from "@fishjam-cloud/ts-client";
+import type { FishjamClient } from "@fishjam-cloud/tsunami";
 
 import type { BandwidthLimits, Track, TrackId } from "../types/public";
 


### PR DESCRIPTION
Stacked on #586.

## Description

- The provider wraps the (optionally injected) ts-client in a tsunami `FishjamClient`; `FishjamClientContext` holds the wrapper.
- `usePeerStatus` / `useReconnection` / `useFishjamClientState` become `useSyncExternalStore` reads over the store; `usePeers` consumes the snapshot.
- Device, screen-share, and custom-source paths stay on the existing hooks — only retyped against the wrapper here; they migrate in follow-up PRs.
- `useScreenshareManager` now **awaits** `addTrack`, so publish failures surfaced as rejections land in the existing `TrackTypeError` recovery and keep the local track alive (error-model follow-through from FCE-3580).

## Motivation and Context

First hook-swap step of FCE-3589: connection state moves off hand-tracked events onto the tsunami store with no public API change — 69/69 specs pass with spec files byte-identical to `tsunami-migration`. Net −112 lines.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
