### PR TITLE
FCE-3586: device foundation — classified errors, platform types, mediaInitializer

### DIFF
--- a/packages/tsunami/src/devices/WebDeviceManager.ts
+++ b/packages/tsunami/src/devices/WebDeviceManager.ts
@@ -1,4 +1,5 @@
 import type { DeviceItem, DeviceType, IDeviceManager, IDevicePersistence } from "./deviceManager";
+import { classifyDeviceError } from "./errors";
 
 export type WebDeviceManagerOptions = {
   persistence?: IDevicePersistence;
@@ -28,15 +29,30 @@ export class WebDeviceManager implements IDeviceManager<MediaStream> {
   }
 
   public async getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream> {
-    return this.getMediaDevices().getUserMedia(constraints);
+    const mediaDevices = this.getMediaDevices();
+    try {
+      return await mediaDevices.getUserMedia(constraints);
+    } catch (error) {
+      throw classifyDeviceError(error);
+    }
   }
 
   public async getDisplayMedia(options?: DisplayMediaStreamOptions): Promise<MediaStream> {
-    return this.getMediaDevices().getDisplayMedia(options);
+    const mediaDevices = this.getMediaDevices();
+    try {
+      return await mediaDevices.getDisplayMedia(options);
+    } catch (error) {
+      throw classifyDeviceError(error);
+    }
   }
 
   public onDeviceChange(callback: () => void): () => void {
     const mediaDevices = this.getMediaDevices();
+
+    // React Native's polyfilled navigator.mediaDevices has no devicechange
+    // events; device-list refreshes then only happen on explicit operations.
+    if (typeof mediaDevices.addEventListener !== "function") return () => {};
+
     const listener = () => callback();
     let subscribed = true;
 

--- a/packages/tsunami/src/devices/constraints.ts
+++ b/packages/tsunami/src/devices/constraints.ts
@@ -1,0 +1,31 @@
+export const VIDEO_TRACK_CONSTRAINTS: MediaTrackConstraints = {
+  width: {
+    max: 1280,
+    ideal: 1280,
+    min: 640,
+  },
+  height: {
+    max: 720,
+    ideal: 720,
+    min: 320,
+  },
+  frameRate: {
+    max: 30,
+    ideal: 24,
+  },
+};
+
+export const prepareConstraints = (
+  deviceIdToStart: string | undefined,
+  constraints: MediaTrackConstraints | undefined | boolean,
+): MediaTrackConstraints | undefined | boolean => {
+  if (!deviceIdToStart) return constraints;
+
+  // The resulting stream will not contain a track of this type,
+  // which means that the device will not be activated.
+  if (constraints === false) return false;
+
+  const constraintsObject = constraints === true ? {} : constraints;
+
+  return { ...constraintsObject, deviceId: { ideal: deviceIdToStart } };
+};

--- a/packages/tsunami/src/devices/deviceManager.ts
+++ b/packages/tsunami/src/devices/deviceManager.ts
@@ -1,27 +1,67 @@
 export type DeviceType = "audio" | "video";
 
+/**
+ * `deviceId` is not guaranteed to be stable across sessions — platforms may
+ * rotate ids between runs, so the label is the more durable identity for a
+ * device that outlives the current session.
+ */
 export type DeviceItem = {
   deviceId: string;
   label: string;
   kind: DeviceType;
 };
 
-/** Optional storage for the last device selected for each media kind. */
+/**
+ * Optional storage for the last device selected for each media kind.
+ *
+ * Because device ids can rotate between sessions (see {@link DeviceItem}), a
+ * stored record's `deviceId` may no longer resolve when it is read back;
+ * consumers re-match records against a fresh enumeration, falling back to the
+ * label.
+ */
 export interface IDevicePersistence {
   getLastDevice(type: DeviceType): DeviceItem | null | Promise<DeviceItem | null>;
   saveLastDevice(type: DeviceType, device: DeviceItem): void | Promise<void>;
 }
 
 /**
+ * Minimal track surface the SDK core relies on. Both the DOM
+ * `MediaStreamTrack` and react-native-webrtc's `MediaStreamTrack` satisfy it
+ * structurally, so the core never depends on either platform's full type.
+ */
+export interface PlatformMediaStreamTrack {
+  readonly id: string;
+  enabled: boolean;
+  stop(): void;
+  getSettings(): { deviceId?: string };
+  // Optional because react-native-webrtc's bundled declarations do not expose
+  // the listener methods inherited from its EventTarget shim (FCE-3689), even
+  // though the runtime objects have them. Callers feature-detect at runtime.
+  addEventListener?(type: "ended", listener: () => void): void;
+  removeEventListener?(type: "ended", listener: () => void): void;
+}
+
+/** Minimal stream surface the SDK core relies on — see {@link PlatformMediaStreamTrack}. */
+export interface PlatformMediaStream {
+  getTracks(): PlatformMediaStreamTrack[];
+  getVideoTracks(): PlatformMediaStreamTrack[];
+  getAudioTracks(): PlatformMediaStreamTrack[];
+}
+
+/**
  * Platform boundary for local media acquisition.
  *
  * The SDK core uses this interface instead of accessing platform globals such
- * as `navigator.mediaDevices`. Implementations may use browser APIs, native
- * APIs, or deterministic test doubles.
+ * as `navigator.mediaDevices`, and only relies on the
+ * {@link PlatformMediaStream} surface of the returned streams. Implementations
+ * may use browser APIs, native APIs, or deterministic test doubles.
+ *
+ * `getUserMedia` and `getDisplayMedia` reject with a classified `DeviceError`
+ * — platform error shapes never cross this boundary.
  *
  * @typeParam TMediaStream - Stream type returned by the target platform.
  */
-export interface IDeviceManager<TMediaStream = MediaStream> {
+export interface IDeviceManager<TMediaStream extends PlatformMediaStream = MediaStream> {
   readonly persistence?: IDevicePersistence;
 
   enumerateDevices(): Promise<DeviceItem[]>;

--- a/packages/tsunami/src/devices/errors.ts
+++ b/packages/tsunami/src/devices/errors.ts
@@ -1,0 +1,74 @@
+import { type ErrorRecoverability, FishjamError } from "../errors/FishjamError";
+
+export type DeviceErrorName = "NotAllowedError" | "NotFoundError" | "OverconstrainedError" | "UNHANDLED_ERROR";
+
+/**
+ * A local media device could not be acquired. Rejected by device operations
+ * and mirrored into the matching `ClientState` error field; a later success
+ * on the same device clears it.
+ */
+export abstract class DeviceError extends FishjamError {
+  public abstract override readonly name: DeviceErrorName;
+}
+
+/** The user (or browser policy) denied access to the device. */
+export class DevicePermissionDeniedError extends DeviceError {
+  public override readonly name = "NotAllowedError";
+  public readonly recoverability: ErrorRecoverability = "user_action";
+
+  public constructor(options?: { cause?: unknown }) {
+    super("Permission to use the device was denied", options);
+  }
+}
+
+/** No device of the requested kind is available. */
+export class DeviceNotFoundError extends DeviceError {
+  public override readonly name = "NotFoundError";
+  public readonly recoverability: ErrorRecoverability = "user_action";
+
+  public constructor(options?: { cause?: unknown }) {
+    super("No matching device was found", options);
+  }
+}
+
+/** The requested constraints cannot be satisfied by any available device. */
+export class DeviceOverconstrainedError extends DeviceError {
+  public override readonly name = "OverconstrainedError";
+  public readonly recoverability: ErrorRecoverability = "retry";
+
+  public constructor(options?: { cause?: unknown }) {
+    super("The requested device constraints cannot be satisfied", options);
+  }
+}
+
+/** Device acquisition failed for a reason the SDK does not recognize. */
+export class UnknownDeviceError extends DeviceError {
+  public override readonly name = "UNHANDLED_ERROR";
+  public readonly recoverability: ErrorRecoverability = "retry";
+
+  public constructor(options?: { cause?: unknown }) {
+    super("Device acquisition failed", options);
+  }
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/API/MediaDevices/getUserMedia#exceptions
+/**
+ * Maps a platform media-acquisition failure to a {@link DeviceError}.
+ * Intended for `IDeviceManager` implementations — the platform error shape
+ * never crosses into the SDK core.
+ */
+export const classifyDeviceError = (error: unknown): DeviceError => {
+  if (error instanceof DeviceError) return error;
+
+  const name = error instanceof Error ? error.name : "";
+  switch (name) {
+    case "NotAllowedError":
+      return new DevicePermissionDeniedError({ cause: error });
+    case "OverconstrainedError":
+      return new DeviceOverconstrainedError({ cause: error });
+    case "NotFoundError":
+      return new DeviceNotFoundError({ cause: error });
+    default:
+      return new UnknownDeviceError({ cause: error });
+  }
+};

--- a/packages/tsunami/src/devices/mediaInitializer.ts
+++ b/packages/tsunami/src/devices/mediaInitializer.ts
@@ -1,0 +1,167 @@
+import { prepareConstraints } from "./constraints";
+import type { DeviceItem, IDeviceManager, PlatformMediaStream } from "./deviceManager";
+import { DeviceError, DeviceOverconstrainedError, DevicePermissionDeniedError, UnknownDeviceError } from "./errors";
+
+type AudioVideo<T> = { audio: T; video: T };
+
+type MediaConstraints = AudioVideo<MediaTrackConstraints | undefined | boolean>;
+type PreviousDevices = AudioVideo<DeviceItem | null>;
+
+export type GetMediaResult = { stream: PlatformMediaStream | null; errors: AudioVideo<DeviceError | null> };
+
+const defaultErrors: AudioVideo<DeviceError | null> = { audio: null, video: null };
+
+// The device manager rejects with classified DeviceError instances (see
+// IDeviceManager), so this module only routes on `error.name`.
+const asDeviceError = (error: unknown): DeviceError =>
+  error instanceof DeviceError ? error : new UnknownDeviceError({ cause: error });
+
+const getSingleMedia = async <T extends "audio" | "video">(
+  deviceManager: IDeviceManager<PlatformMediaStream>,
+  type: T,
+  constraints: MediaStreamConstraints[T],
+): Promise<[PlatformMediaStream, null] | [null, DeviceError]> => {
+  const baseConstraints = { audio: undefined, video: undefined };
+
+  try {
+    const stream = await deviceManager.getUserMedia({ ...baseConstraints, [type]: constraints });
+    return [stream, null];
+  } catch (err) {
+    return [null, asDeviceError(err)];
+  }
+};
+
+const tryToGetAudioOnlyThenVideoOnly = async (
+  deviceManager: IDeviceManager<PlatformMediaStream>,
+  constraints: MediaStreamConstraints,
+  initialError: DeviceError,
+): Promise<GetMediaResult> => {
+  const [audioStream, audioError] = await getSingleMedia(deviceManager, "audio", constraints.audio);
+  if (audioStream) return { stream: audioStream, errors: { video: initialError, audio: null } };
+
+  const [videoStream, videoError] = await getSingleMedia(deviceManager, "video", constraints.video);
+  return { stream: videoStream, errors: { audio: audioError, video: videoError } };
+};
+
+export const getAvailableMedia = async (
+  deviceManager: IDeviceManager<PlatformMediaStream>,
+  constraints: MediaStreamConstraints,
+  errors: AudioVideo<DeviceError | null> = defaultErrors,
+): Promise<GetMediaResult> => {
+  try {
+    return { stream: await deviceManager.getUserMedia(constraints), errors };
+  } catch (err: unknown) {
+    const deviceError = asDeviceError(err);
+    switch (deviceError.name) {
+      case errors.audio?.name:
+      case errors.video?.name:
+        return { stream: null, errors };
+      case "NotFoundError":
+      case "NotAllowedError":
+        return tryToGetAudioOnlyThenVideoOnly(
+          deviceManager,
+          constraints,
+          new DevicePermissionDeniedError({ cause: err }),
+        );
+      case "OverconstrainedError":
+        return getAvailableMedia(
+          deviceManager,
+          { audio: unspecifyDevice(constraints.audio), video: unspecifyDevice(constraints.video) },
+          { audio: deviceError, video: new DeviceOverconstrainedError({ cause: err }) },
+        );
+      default:
+        return { stream: null, errors: { audio: deviceError, video: new UnknownDeviceError({ cause: err }) } };
+    }
+  }
+};
+
+/**
+ * Re-acquires the last session's persisted devices when the initial
+ * acquisition landed on different ones.
+ *
+ * Device ids are not stable across sessions (see {@link DeviceItem}), so a
+ * stale persisted id can make the platform silently hand out a default
+ * device. Persisted devices are re-matched against the current enumeration by
+ * label; when found, the acquired tracks are stopped and the persisted
+ * devices are re-acquired with exact ids. Runs only during device
+ * initialization — labels only become visible once an acquisition has been
+ * granted, which is what forces this recover-after-acquire ordering.
+ */
+export const recoverPersistedDevices = async (
+  deviceManager: IDeviceManager<PlatformMediaStream>,
+  stream: PlatformMediaStream,
+  errors: AudioVideo<DeviceError | null>,
+  devices: DeviceItem[],
+  constraints: MediaConstraints,
+  previousDevices: PreviousDevices,
+): Promise<GetMediaResult> => {
+  const shouldCorrectDevices = isAnyDeviceDifferentFromLastSession(
+    previousDevices.video,
+    previousDevices.audio,
+    getCurrentDevicesSettings(stream, devices),
+  );
+
+  if (!shouldCorrectDevices) return { stream, errors };
+
+  const videoIdToStart = devices.find((device) => device.label === previousDevices.video?.label)?.deviceId;
+  const audioIdToStart = devices.find((device) => device.label === previousDevices.audio?.label)?.deviceId;
+
+  if (!videoIdToStart && !audioIdToStart) return { stream, errors };
+
+  stopTracks(stream);
+
+  const exactConstraints: MediaStreamConstraints = {
+    video: !errors.video && prepareConstraints(videoIdToStart, constraints.video),
+    audio: !errors.audio && prepareConstraints(audioIdToStart, constraints.audio),
+  };
+
+  return await getAvailableMedia(deviceManager, exactConstraints, errors);
+};
+
+type CurrentDevices = AudioVideo<DeviceItem | null>;
+
+const getCurrentDevicesSettings = (
+  requestedDevices: PlatformMediaStream,
+  availableDevices: DeviceItem[],
+): CurrentDevices => {
+  const currentDevices: CurrentDevices = { video: null, audio: null };
+
+  for (const track of requestedDevices.getTracks()) {
+    const settings = track.getSettings();
+    if (settings.deviceId) {
+      const currentDevice = availableDevices.find((device) => device.deviceId == settings.deviceId);
+      if (currentDevice && (currentDevice.kind === "video" || currentDevice.kind === "audio")) {
+        currentDevices[currentDevice.kind] = currentDevice;
+      }
+    }
+  }
+  return currentDevices;
+};
+
+const isDeviceDifferentFromLastSession = (lastDevice: DeviceItem | null, currentDevice: DeviceItem | null) =>
+  lastDevice && (currentDevice?.deviceId !== lastDevice.deviceId || currentDevice?.label !== lastDevice?.label);
+
+const isAnyDeviceDifferentFromLastSession = (
+  lastVideoDevice: DeviceItem | null,
+  lastAudioDevice: DeviceItem | null,
+  currentDevices: CurrentDevices | null,
+): boolean =>
+  !!(
+    (currentDevices?.video && isDeviceDifferentFromLastSession(lastVideoDevice, currentDevices?.video || null)) ||
+    (currentDevices?.audio && isDeviceDifferentFromLastSession(lastAudioDevice, currentDevices?.audio || null))
+  );
+
+const stopTracks = (requestedDevices: PlatformMediaStream) => {
+  for (const track of requestedDevices.getTracks()) {
+    track.stop();
+  }
+};
+
+const unspecifyDevice = (
+  trackConstraints?: boolean | MediaTrackConstraints,
+): boolean | MediaTrackConstraints | undefined => {
+  if (typeof trackConstraints === "object") {
+    return { ...trackConstraints, deviceId: undefined };
+  }
+  return trackConstraints;
+};

--- a/packages/tsunami/src/mediaTypes.ts
+++ b/packages/tsunami/src/mediaTypes.ts
@@ -1,0 +1,48 @@
+import type { Variant } from "@fishjam-cloud/ts-client";
+
+import type { PlatformMediaStream, PlatformMediaStreamTrack } from "./devices/deviceManager";
+import type { DeviceError } from "./devices/errors";
+
+export type MiddlewareResult = { track: PlatformMediaStreamTrack; onClear?: () => void };
+
+/**
+ * Transforms a single local track (e.g. background blur) before it is
+ * published. Passing `null` removes the current middleware.
+ */
+export type TrackMiddleware =
+  | ((track: PlatformMediaStreamTrack) => MiddlewareResult | Promise<MiddlewareResult>)
+  | null;
+
+export type TracksMiddlewareResult = {
+  videoTrack: PlatformMediaStreamTrack;
+  audioTrack: PlatformMediaStreamTrack | null;
+  onClear: () => void;
+};
+
+/**
+ * Transforms a screen-share track pair before it is published.
+ */
+export type TracksMiddleware = (
+  videoTrack: PlatformMediaStreamTrack,
+  audioTrack: PlatformMediaStreamTrack | null,
+) => TracksMiddlewareResult | Promise<TracksMiddlewareResult>;
+
+export type SimulcastBandwidthLimits = {
+  [Variant.VARIANT_LOW]: number;
+  [Variant.VARIANT_MEDIUM]: number;
+  [Variant.VARIANT_HIGH]: number;
+};
+
+export type BandwidthLimits = { singleStream: number; simulcast: SimulcastBandwidthLimits };
+
+export type StreamConfig = { sentQualities?: Variant[] | false };
+
+export type InitializeDevicesStatus = "initialized" | "failed" | "initialized_with_errors" | "already_initialized";
+
+export type InitializeDevicesResult = {
+  status: InitializeDevicesStatus;
+  stream: PlatformMediaStream | null;
+  errors: { audio: DeviceError | null; video: DeviceError | null } | null;
+};
+
+export type InitializeDevicesSettings = { enableVideo?: boolean; enableAudio?: boolean };


### PR DESCRIPTION
## Description

- `devices/errors.ts`: `DeviceError` classes with the legacy name literals (`NotAllowedError` / `NotFoundError` / `OverconstrainedError` / `UNHANDLED_ERROR`), recoverability, and the platform cause. Classification happens at the platform boundary: `WebDeviceManager.getUserMedia` / `getDisplayMedia` reject with a classified `DeviceError`, so raw platform error shapes never cross into the core.
- `IDeviceManager` gains the `PlatformMediaStreamTrack` / `PlatformMediaStream` structural contracts — the core no longer types against DOM media, and react-native-webrtc's runtime objects satisfy them (listener methods stay optional per FCE-3689). `onDeviceChange` feature-detects `mediaDevices` without devicechange events (React Native's polyfill).
- `devices/mediaInitializer.ts`: `getAvailableMedia` fallback ladder (audio-only / video-only on failure, Overconstrained retry with stripped deviceId) + `recoverPersistedDevices` — the platform contract states device ids are NOT stable across sessions, so a persisted device that resolves to nothing is re-matched by label and re-acquired with exact ids (no browser knowledge in the core).
- `mediaTypes.ts`: the public middleware/initialization types. Exported once the device API lands (next PRs in the stack).

## Motivation and Context

Foundation layer for porting device logic out of react-client: typed errors per the FCE-3580 error model, and a platform boundary that keeps the core free of `navigator.mediaDevices` and DOM media types.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
