### PR TITLE
FCE-3582: DeviceOrchestrator and the client device API

### DIFF
--- a/packages/tsunami/src/FishjamClient.ts
+++ b/packages/tsunami/src/FishjamClient.ts
@@ -8,17 +8,30 @@ import {
   FishjamClient as TsClient,
   type FishjamTrackContext,
   type GenericMetadata,
+  getLogger,
   type MessageEvents,
   type Peer,
   type SimulcastConfig,
   type TrackBandwidthLimit,
   type TrackMetadata,
-  type Variant,
+  Variant,
 } from "@fishjam-cloud/ts-client";
 import { EventEmitter } from "events";
 import type TypedEmitter from "typed-emitter";
 
 import { ClientResourceScope } from "./ClientResourceScope";
+import { DeviceOrchestrator } from "./controllers/DeviceOrchestrator";
+import type { TrackPublisher } from "./controllers/TrackPublisher";
+import { VIDEO_TRACK_CONSTRAINTS } from "./devices/constraints";
+import type { IDeviceManager, PlatformMediaStream, PlatformMediaStreamTrack } from "./devices/deviceManager";
+import { DeviceManagerMissingError } from "./errors/lifecycleErrors";
+import type {
+  BandwidthLimits,
+  InitializeDevicesResult,
+  InitializeDevicesSettings,
+  StreamConfig,
+  TrackMiddleware,
+} from "./mediaTypes";
 import { type ClientState, createInitialClientState } from "./state/clientState";
 import { StateStore, type StoreListener } from "./state/StateStore";
 
@@ -28,6 +41,19 @@ type LegacyClientInternals<PeerMetadata> = {
 };
 
 export type FishjamClientConfig<PeerMetadata = GenericMetadata, ServerMetadata = GenericMetadata> = CreateConfig & {
+  /**
+   * Platform boundary for local media acquisition. Any implementation works
+   * equally: `WebDeviceManager` (what the React provider injects on the web),
+   * a native implementation, or a custom one. When omitted (or `null`) the
+   * client is signalling-only and all device-related state stays at its zero
+   * values.
+   */
+  deviceManager?: IDeviceManager<PlatformMediaStream> | null;
+  videoConstraints?: MediaTrackConstraints | boolean;
+  audioConstraints?: MediaTrackConstraints | boolean;
+  bandwidthLimits?: Partial<BandwidthLimits>;
+  videoStreamConfig?: StreamConfig;
+  audioStreamConfig?: StreamConfig;
   /**
    * Strangler-migration hook: use an externally created signalling client
    * instead of constructing one. Also the seam tests inject fakes through.
@@ -90,9 +116,20 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     createInitialClientState<PeerMetadata, ServerMetadata>(),
   );
 
+  private readonly deviceOrchestrator: DeviceOrchestrator<PeerMetadata, ServerMetadata> | null = null;
+
   public constructor(config?: FishjamClientConfig<PeerMetadata, ServerMetadata>) {
     super();
-    const { signallingClient, ...createConfig } = config ?? {};
+    const {
+      deviceManager,
+      videoConstraints,
+      audioConstraints,
+      bandwidthLimits,
+      videoStreamConfig,
+      audioStreamConfig,
+      signallingClient,
+      ...createConfig
+    } = config ?? {};
     this.config = createConfig;
 
     this.bindSessionStateEvents();
@@ -103,6 +140,131 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
       this.tsClient = signallingClient;
       this.wireTsClient(signallingClient);
     }
+
+    if (deviceManager) {
+      this.deviceOrchestrator = new DeviceOrchestrator<PeerMetadata, ServerMetadata>({
+        publisher: this.createTrackPublisher(),
+        deviceManager,
+        store: this.store,
+        logger: getLogger(config?.debug ?? false),
+        videoConstraints: videoConstraints ?? VIDEO_TRACK_CONSTRAINTS,
+        audioConstraints: audioConstraints ?? true,
+        videoStreamConfig,
+        audioStreamConfig,
+        bandwidthLimits: {
+          singleStream: bandwidthLimits?.singleStream ?? 0,
+          simulcast: bandwidthLimits?.simulcast ?? {
+            [Variant.VARIANT_LOW]: 0,
+            [Variant.VARIANT_MEDIUM]: 0,
+            [Variant.VARIANT_HIGH]: 0,
+          },
+        },
+      });
+    }
+  }
+
+  /**
+   * Device controllers backing the high-level device API. Exposed for the
+   * framework adapters during the strangler migration; application code
+   * should use the `startCamera`-style methods instead.
+   *
+   * @internal
+   */
+  public get devices(): DeviceOrchestrator<PeerMetadata, ServerMetadata> | null {
+    return this.deviceOrchestrator;
+  }
+
+  // --- device API (available when a deviceManager was injected) ---
+
+  public initializeDevices(settings?: InitializeDevicesSettings): Promise<InitializeDevicesResult> {
+    return this.requireDevices().initializeDevices(settings);
+  }
+
+  public async startCamera(deviceId?: string): Promise<void> {
+    await this.requireDevices().camera.start(deviceId);
+  }
+
+  public async stopCamera(): Promise<void> {
+    await this.requireDevices().camera.stop();
+  }
+
+  public async toggleCamera(): Promise<void> {
+    await this.requireDevices().camera.toggleDevice();
+  }
+
+  public async selectCamera(deviceId: string): Promise<void> {
+    await this.requireDevices().camera.selectDevice(deviceId);
+  }
+
+  public async setCameraTrackMiddleware(middleware: TrackMiddleware): Promise<void> {
+    await this.requireDevices().camera.setTrackMiddleware(middleware);
+  }
+
+  public async startMicrophone(deviceId?: string): Promise<void> {
+    await this.requireDevices().microphone.start(deviceId);
+  }
+
+  public async stopMicrophone(): Promise<void> {
+    await this.requireDevices().microphone.stop();
+  }
+
+  public async toggleMicrophone(): Promise<void> {
+    await this.requireDevices().microphone.toggleDevice();
+  }
+
+  public async toggleMicrophoneMute(): Promise<void> {
+    await this.requireDevices().microphone.toggleMute();
+  }
+
+  public async selectMicrophone(deviceId: string): Promise<void> {
+    await this.requireDevices().microphone.selectDevice(deviceId);
+  }
+
+  public async setMicrophoneTrackMiddleware(middleware: TrackMiddleware): Promise<void> {
+    await this.requireDevices().microphone.setTrackMiddleware(middleware);
+  }
+
+  private requireDevices(): DeviceOrchestrator<PeerMetadata, ServerMetadata> {
+    this.resources.assertActive();
+    if (!this.deviceOrchestrator) throw new DeviceManagerMissingError();
+    return this.deviceOrchestrator;
+  }
+
+  private createTrackPublisher(): TrackPublisher {
+    // The signalling layer is typed against DOM media types, while the device
+    // layer only knows the platform contract. On React Native the runtime
+    // objects reaching this boundary are react-native-webrtc tracks that the
+    // signalling stack already handles, so the widening cast is confined here.
+    const asSignallingTrack = (track: PlatformMediaStreamTrack | null) => track as MediaStreamTrack | null;
+
+    return {
+      addTrack: (track, metadata, simulcastConfig, maxBandwidth) =>
+        this.addTrack(asSignallingTrack(track) as MediaStreamTrack, metadata, simulcastConfig, maxBandwidth),
+      replaceTrack: (trackId, newTrack) => this.replaceTrack(trackId, asSignallingTrack(newTrack)),
+      removeTrack: (trackId) => this.removeTrack(trackId),
+      updateTrackMetadata: (trackId, metadata) => this.updateTrackMetadata(trackId, metadata),
+      getDisplayName: () => {
+        const peerMetadata = this.getLocalPeer()?.metadata?.peer as Record<string, unknown> | undefined;
+        const displayName = peerMetadata?.displayName;
+        return typeof displayName === "string" ? displayName : undefined;
+      },
+      resolveRemoteTrackId: (remoteOrLocalTrackId) => {
+        const tracks = this.getLocalPeer()?.tracks;
+        if (!tracks) return null;
+        if (tracks.get(remoteOrLocalTrackId)) return remoteOrLocalTrackId;
+        const trackByLocalId = [...tracks.values()].find(({ track }) => track?.id === remoteOrLocalTrackId);
+        return trackByLocalId?.trackId ?? null;
+      },
+      isSignallingActive: () => this.status === "initialized",
+      onJoined: (listener) => {
+        this.on("joined", listener);
+        return () => this.off("joined", listener);
+      },
+      onDisconnected: (listener) => {
+        this.on("disconnected", listener);
+        return () => this.off("disconnected", listener);
+      },
+    };
   }
 
   /** Synchronously readable snapshot of the client's observable state. */
@@ -276,6 +438,7 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     if (this.resources.isDisposed) return;
 
     this.resources.dispose();
+    this.deviceOrchestrator?.dispose();
     this.store.clear();
 
     const tsClient = this.tsClient;

--- a/packages/tsunami/src/controllers/DeviceOrchestrator.ts
+++ b/packages/tsunami/src/controllers/DeviceOrchestrator.ts
@@ -1,0 +1,198 @@
+import type { Logger } from "@fishjam-cloud/ts-client";
+
+import { prepareConstraints } from "../devices/constraints";
+import type { DeviceItem, DeviceType, IDeviceManager, PlatformMediaStream } from "../devices/deviceManager";
+import { getAvailableMedia,recoverPersistedDevices } from "../devices/mediaInitializer";
+import type { BandwidthLimits, InitializeDevicesResult, InitializeDevicesSettings, StreamConfig } from "../mediaTypes";
+import type { ClientState } from "../state/clientState";
+import type { StateStore } from "../state/StateStore";
+import { TrackDeviceController } from "./TrackDeviceController";
+import type { TrackPublisher } from "./TrackPublisher";
+
+export type DeviceOrchestratorDeps<PeerMetadata, ServerMetadata> = {
+  publisher: TrackPublisher;
+  deviceManager: IDeviceManager<PlatformMediaStream>;
+  store: StateStore<ClientState<PeerMetadata, ServerMetadata>>;
+  logger: Logger;
+  videoConstraints?: MediaTrackConstraints | boolean;
+  audioConstraints?: MediaTrackConstraints | boolean;
+  bandwidthLimits: BandwidthLimits;
+  videoStreamConfig?: StreamConfig;
+  audioStreamConfig?: StreamConfig;
+};
+
+/**
+ * Wraps whichever `IDeviceManager` the client config provides —
+ * `WebDeviceManager`, a native implementation, or a custom one; the
+ * orchestrator only ever sees the interface. Owns device initialization,
+ * hardware enumeration, and the per-source controllers, and mirrors all of it
+ * into the client state store. Not created for clients configured without a
+ * device manager (signalling-only mode).
+ */
+export class DeviceOrchestrator<PeerMetadata, ServerMetadata> {
+  public readonly camera: TrackDeviceController;
+  public readonly microphone: TrackDeviceController;
+
+  private deviceList: DeviceItem[] = [];
+  private availableCameras: DeviceItem[] = [];
+  private availableMicrophones: DeviceItem[] = [];
+
+  private isInitialized = false;
+  private initializationPromise: Promise<InitializeDevicesResult> | null = null;
+  private readonly deviceChangeCleanup: () => void;
+
+  public constructor(private readonly deps: DeviceOrchestratorDeps<PeerMetadata, ServerMetadata>) {
+    const commonControllerDeps = {
+      publisher: deps.publisher,
+      deviceManager: deps.deviceManager,
+      logger: deps.logger,
+      getPeerStatus: () => deps.store.getState().peerStatus,
+      getInitialStream: () => this.getInitialStream(),
+      invalidateInitialStream: () => {
+        this.initializationPromise = null;
+      },
+      onStateChanged: () => this.syncStore(),
+    };
+
+    this.camera = new TrackDeviceController({
+      ...commonControllerDeps,
+      type: "video",
+      constraints: deps.videoConstraints,
+      bandwidthLimits: deps.bandwidthLimits,
+      streamConfig: deps.videoStreamConfig,
+      getAvailableDevices: () => this.availableCameras,
+      onSelectedDeviceChanged: (device) => this.persistLastDevice("video", device),
+    });
+
+    this.microphone = new TrackDeviceController({
+      ...commonControllerDeps,
+      type: "audio",
+      constraints: deps.audioConstraints,
+      bandwidthLimits: deps.bandwidthLimits,
+      streamConfig: deps.audioStreamConfig,
+      getAvailableDevices: () => this.availableMicrophones,
+      onSelectedDeviceChanged: (device) => this.persistLastDevice("audio", device),
+    });
+
+    this.deviceChangeCleanup = deps.deviceManager.onDeviceChange(() => {
+      void this.refreshDeviceList().catch((error) => deps.logger.error("Failed to refresh device list", error));
+    });
+
+    this.syncStore();
+  }
+
+  public async initializeDevices(settings?: InitializeDevicesSettings): Promise<InitializeDevicesResult> {
+    if (this.isInitialized) {
+      return { stream: null, errors: null, status: "already_initialized" };
+    }
+    if (this.initializationPromise) {
+      return this.initializationPromise;
+    }
+
+    const persistence = this.deps.deviceManager.persistence;
+    const lastUsed = {
+      audio: (await persistence?.getLastDevice("audio")) ?? null,
+      video: (await persistence?.getLastDevice("video")) ?? null,
+    };
+
+    const constraints = {
+      video:
+        settings?.enableVideo !== false && prepareConstraints(lastUsed.video?.deviceId, this.deps.videoConstraints),
+      audio:
+        settings?.enableAudio !== false && prepareConstraints(lastUsed.audio?.deviceId, this.deps.audioConstraints),
+    };
+
+    const initialize = async (): Promise<InitializeDevicesResult> => {
+      let media = await getAvailableMedia(this.deps.deviceManager, constraints);
+      await this.refreshDeviceList();
+
+      if (media.stream) {
+        media = await recoverPersistedDevices(
+          this.deps.deviceManager,
+          media.stream,
+          media.errors,
+          this.deviceList,
+          constraints,
+          lastUsed,
+        );
+      }
+
+      const { stream, errors } = media;
+
+      const videoDeviceId = stream?.getVideoTracks()[0]?.getSettings().deviceId;
+      const audioDeviceId = stream?.getAudioTracks()[0]?.getSettings().deviceId;
+
+      const videoDevice = this.availableCameras.find((device) => device.deviceId === videoDeviceId);
+      const audioDevice = this.availableMicrophones.find((device) => device.deviceId === audioDeviceId);
+
+      if (videoDevice) this.camera.setSelectedDevice(videoDevice);
+      if (audioDevice) this.microphone.setSelectedDevice(audioDevice);
+
+      // Both controllers adopt the same stream; each only ever touches tracks
+      // of its own kind.
+      this.camera.adoptInitialStream(stream);
+      this.microphone.adoptInitialStream(stream);
+      this.camera.setError(errors.video);
+      this.microphone.setError(errors.audio);
+
+      if (!stream) {
+        return { status: "failed", errors, stream: null };
+      } else if (errors.video || errors.audio) {
+        return { status: "initialized_with_errors", errors, stream: null };
+      } else {
+        return { status: "initialized", errors: null, stream };
+      }
+    };
+
+    const initializationPromise = initialize().then(
+      (result) => {
+        this.isInitialized = true;
+        this.syncStore();
+        return result;
+      },
+      (error) => {
+        this.initializationPromise = null;
+        throw error;
+      },
+    );
+    this.initializationPromise = initializationPromise;
+
+    return initializationPromise;
+  }
+
+  public dispose(): void {
+    this.deviceChangeCleanup();
+    this.camera.dispose();
+    this.microphone.dispose();
+  }
+
+  private async getInitialStream(): Promise<PlatformMediaStream | null> {
+    const result = await this.initializationPromise;
+    return result?.stream ?? null;
+  }
+
+  private async refreshDeviceList(): Promise<void> {
+    this.deviceList = await this.deps.deviceManager.enumerateDevices();
+    this.availableCameras = this.deviceList.filter((device) => device.kind === "video");
+    this.availableMicrophones = this.deviceList.filter((device) => device.kind === "audio");
+    this.syncStore();
+  }
+
+  private persistLastDevice(type: DeviceType, device: DeviceItem): void {
+    void Promise.resolve(this.deps.deviceManager.persistence?.saveLastDevice(type, device)).catch((error) =>
+      this.deps.logger.warn({ name: "Failed to persist last device", error }),
+    );
+  }
+
+  private syncStore(): void {
+    this.deps.store.update({
+      camera: this.camera.snapshot(),
+      microphone: this.microphone.snapshot(),
+      availableCameras: this.availableCameras,
+      availableMicrophones: this.availableMicrophones,
+      cameraError: this.camera.error,
+      microphoneError: this.microphone.error,
+      devicesInitialized: this.isInitialized,
+    } as Partial<ClientState<PeerMetadata, ServerMetadata>>);
+  }
+}

--- a/packages/tsunami/src/errors/lifecycleErrors.ts
+++ b/packages/tsunami/src/errors/lifecycleErrors.ts
@@ -15,3 +15,17 @@ export class ClientDisposedError extends FishjamError {
     this.name = "ClientDisposedError";
   }
 }
+
+/**
+ * Thrown when a device-related method is called on a client that was created
+ * without a device manager. Construct the client with a `deviceManager` to
+ * use the device API; a signalling-only client cannot acquire local media.
+ */
+export class DeviceManagerMissingError extends FishjamError {
+  public readonly recoverability: ErrorRecoverability = "fatal";
+
+  public constructor() {
+    super("This FishjamClient was created without a device manager, so the device API is unavailable");
+    this.name = "DeviceManagerMissingError";
+  }
+}

--- a/packages/tsunami/src/index.ts
+++ b/packages/tsunami/src/index.ts
@@ -3,19 +3,45 @@
  *
  * @packageDocumentation
  */
-export type { DeviceItem, DeviceType, IDeviceManager, IDevicePersistence } from "./devices/deviceManager";
+export type { DeviceOrchestrator } from "./controllers/DeviceOrchestrator";
+export type { TrackDeviceController } from "./controllers/TrackDeviceController";
+export type {
+  DeviceItem,
+  DeviceType,
+  IDeviceManager,
+  IDevicePersistence,
+  PlatformMediaStream,
+  PlatformMediaStreamTrack,
+} from "./devices/deviceManager";
+export {
+  classifyDeviceError,
+  DeviceError,
+  type DeviceErrorName,
+  DeviceNotFoundError,
+  DeviceOverconstrainedError,
+  DevicePermissionDeniedError,
+  UnknownDeviceError,
+} from "./devices/errors";
 export { LocalStorageDevicePersistence } from "./devices/LocalStorageDevicePersistence";
 export { WebDeviceManager, type WebDeviceManagerOptions } from "./devices/WebDeviceManager";
 export { type ErrorRecoverability, FishjamError } from "./errors/FishjamError";
-export { ClientDisposedError } from "./errors/lifecycleErrors";
+export { ClientDisposedError, DeviceManagerMissingError } from "./errors/lifecycleErrors";
 export { FishjamClient, type FishjamClientConfig } from "./FishjamClient";
-export { type ClientState, createInitialClientState, type PeerStatus } from "./state/clientState";
+export type {
+  BandwidthLimits,
+  InitializeDevicesResult,
+  InitializeDevicesSettings,
+  InitializeDevicesStatus,
+  MiddlewareResult,
+  SimulcastBandwidthLimits,
+  StreamConfig,
+  TrackMiddleware,
+} from "./mediaTypes";
+export {
+  type ClientState,
+  createInitialClientState,
+  type LocalDeviceState,
+  type PeerStatus,
+} from "./state/clientState";
 export { StateStore, type StateStoreOptions, type StoreListener } from "./state/StateStore";
 export * from "@fishjam-cloud/ts-client";
-
-export type MiddlewareResult = {
-  track: MediaStreamTrack;
-  onClear?: () => void;
-};
-
-export type TrackMiddleware = ((track: MediaStreamTrack) => MiddlewareResult | Promise<MiddlewareResult>) | null;

--- a/packages/tsunami/src/state/clientState.ts
+++ b/packages/tsunami/src/state/clientState.ts
@@ -1,6 +1,7 @@
 import type { Component, GenericMetadata, Peer, ReconnectionStatus } from "@fishjam-cloud/ts-client";
 
 import type { DeviceItem, PlatformMediaStream, PlatformMediaStreamTrack } from "../devices/deviceManager";
+import type { DeviceError } from "../devices/errors";
 import type { TrackMiddleware } from "../mediaTypes";
 
 /**
@@ -41,7 +42,27 @@ export interface ClientState<PeerMetadata = GenericMetadata, ServerMetadata = Ge
   localPeer: Peer<PeerMetadata, ServerMetadata> | null;
   remotePeers: Record<string, Peer<PeerMetadata, ServerMetadata>>;
   components: Record<string, Component>;
+
+  // local devices
+  camera: LocalDeviceState;
+  microphone: LocalDeviceState;
+
+  // available hardware
+  availableCameras: DeviceItem[];
+  availableMicrophones: DeviceItem[];
+  cameraError: DeviceError | null;
+  microphoneError: DeviceError | null;
+  devicesInitialized: boolean;
 }
+
+const createInitialDeviceState = (): LocalDeviceState => ({
+  track: null,
+  stream: null,
+  isEnabled: true,
+  activeDevice: null,
+  selectedDevice: null,
+  middleware: null,
+});
 
 export const createInitialClientState = <PeerMetadata, ServerMetadata>(): ClientState<
   PeerMetadata,
@@ -52,4 +73,11 @@ export const createInitialClientState = <PeerMetadata, ServerMetadata>(): Client
   localPeer: null,
   remotePeers: {},
   components: {},
+  camera: createInitialDeviceState(),
+  microphone: createInitialDeviceState(),
+  availableCameras: [],
+  availableMicrophones: [],
+  cameraError: null,
+  microphoneError: null,
+  devicesInitialized: false,
 });


### PR DESCRIPTION
Stacked on #590.

> Note for reviewers: this PR adds the orchestrator and the `deviceManager` injection point but contains **no production caller** — the orchestrator works with any `IDeviceManager` implementation, and react-client injects `WebDeviceManager` through this exact config key one PR up, in #592.

## Description

- `DeviceOrchestrator`: owns the camera + microphone controllers, `initializeDevices`, and hardware enumeration, and mirrors everything into the `StateStore` with one update per effective change. Keeps the pinned init semantics: in-flight promise reuse, rejection resets, `already_initialized` short-circuit, one shared initial stream adopted by both controllers (each touches only tracks of its own kind), last-device persistence, and persisted-device recovery by label (device ids are not session-stable per the platform contract).
- `ClientState` grows the device slices: `camera`, `microphone`, `availableCameras`, `availableMicrophones`, `cameraError`, `microphoneError`, `devicesInitialized`.
- `FishjamClient` grows the device config (`deviceManager` injection point, constraints, bandwidth limits, stream configs) and the camera/microphone/`initializeDevices` methods. Without an injected `deviceManager` the client stays **signalling-only**: no orchestrator, device state at zero values, device methods throw `DeviceManagerMissingError`.

## Motivation and Context

The orchestrator skeleton from RFC 0015 §5 with the signalling-only optionality FCE-3582 calls for; also delivers the `initializeDevices` port (FCE-3586). The react-client swap onto this API is the next PR in the stack.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
