### PR TITLE
FCE-3578: data-channel state moves into ClientState

### DIFF
--- a/packages/react-client/src/hooks/useDataChannel.ts
+++ b/packages/react-client/src/hooks/useDataChannel.ts
@@ -1,104 +1,53 @@
 import type { DataCallback, DataChannelOptions } from "@fishjam-cloud/ts-client";
-import { useCallback, useContext, useEffect, useState } from "react";
+import { useCallback, useContext, useSyncExternalStore } from "react";
 
 import { FishjamClientContext } from "../contexts/fishjamClient";
-import { PeerStatusContext } from "../contexts/peerStatus";
 import type { UseDataChannelResult } from "../types/public";
-import { useCurrentCallback } from "./internal/useCurrentCallback";
 
 /**
- * Hook for data channel operations - publish and subscribe to data.
+ * Hook for managing data channels: initialization, publishing and subscribing to data.
  *
  * @category Connection
  * @group Hooks
  */
 export function useDataChannel(): UseDataChannelResult {
   const fishjamClientRef = useContext(FishjamClientContext);
-  const peerStatus = useContext(PeerStatusContext);
-
   if (!fishjamClientRef) throw Error("useDataPublisher must be used within FishjamProvider");
-
   const client = fishjamClientRef.current;
-  const [ready, setReady] = useState(false);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
 
-  useEffect(() => {
-    const publisherReady = client.getDataChannelsReadiness();
-    setReady(publisherReady);
+  const dataChannel = useSyncExternalStore(
+    client.subscribe,
+    useCallback(() => client.getState().dataChannel, [client]),
+  );
 
-    const handleReady = () => {
-      setReady(true);
-      setError(null);
-    };
-    const handleDisconnect = () => {
-      setReady(false);
-    };
-    const handleError = (err: Error) => {
-      setReady(false);
-      setLoading(false);
-      setError(err);
-    };
-
-    client.on("dataChannelsReady", handleReady);
-    client.on("dataChannelsError", handleError);
-    client.on("disconnected", handleDisconnect);
-
-    return () => {
-      client.removeListener("dataChannelsReady", handleReady);
-      client.removeListener("disconnected", handleDisconnect);
-    };
+  const initializeDataChannel = useCallback(() => {
+    // Failures surface through the state slice, matching the hook's
+    // historical non-throwing contract.
+    void client.createDataChannels().catch(() => undefined);
   }, [client]);
 
-  // Stable identity with a live closure: peerStatus / loading / ready must be
-  // observed at call time so a captured reference doesn't reject with a stale
-  // "Peer is not connected" right after the connect promise settles.
-  const initialize = useCurrentCallback(async () => {
-    if (loading || ready) return;
-
-    if (peerStatus !== "connected") {
-      setError(new Error("Peer is not connected"));
-      return;
-    }
-
-    try {
-      setLoading(true);
-      await client.createDataChannels();
-    } catch (err) {
-      if (err instanceof Error) {
-        setError(err);
-      }
-    } finally {
-      setLoading(false);
-    }
-  });
-
   const publishData = useCallback(
-    (data: Uint8Array, options: DataChannelOptions) => {
+    (payload: Uint8Array, options: DataChannelOptions) => {
       try {
-        client.publishData(data, options);
-      } catch (err) {
-        if (err instanceof Error) {
-          setError(err);
-        }
+        client.publishData(payload, options);
+      } catch {
+        // Mirrored into the state slice by the client.
       }
     },
     [client],
   );
 
   const subscribeData = useCallback(
-    (callback: DataCallback, options: DataChannelOptions): (() => void) => {
-      return client.subscribeData(callback, options);
-    },
+    (callback: DataCallback, options: DataChannelOptions) => client.subscribeData(callback, options),
     [client],
   );
 
   return {
+    initializeDataChannel,
     publishData,
     subscribeData,
-    initializeDataChannel: initialize,
-    dataChannelReady: ready,
-    dataChannelLoading: loading,
-    dataChannelError: error,
+    dataChannelReady: dataChannel.status === "ready",
+    dataChannelLoading: dataChannel.status === "creating",
+    dataChannelError: dataChannel.error,
   };
 }

--- a/packages/tsunami/src/FishjamClient.sessionState.test.ts
+++ b/packages/tsunami/src/FishjamClient.sessionState.test.ts
@@ -2,6 +2,7 @@ import type { Component, FishjamClient as TsClient, GenericMetadata, Peer } from
 import { EventEmitter } from "events";
 import { describe, expect, it, vi } from "vitest";
 
+import { DataChannelsNotConnectedError } from "./errors/lifecycleErrors";
 import { FishjamClient } from "./FishjamClient";
 
 class FakeSignallingClient extends EventEmitter {
@@ -15,6 +16,9 @@ class FakeSignallingClient extends EventEmitter {
   public connect = vi.fn(async () => {});
   public disconnect = vi.fn();
   public cleanup = vi.fn();
+  public createDataChannels = vi.fn(async () => {
+    this.emit("dataChannelsReady");
+  });
 }
 
 const createWiredClient = () => {
@@ -151,5 +155,45 @@ describe("FishjamClient session state", () => {
 
     expect(listener).not.toHaveBeenCalled();
     expect(client.getState().peerStatus).toBe("idle");
+  });
+});
+
+describe("FishjamClient data channel state", () => {
+  it("rejects with a typed error and mirrors it when creating channels while not connected", async () => {
+    const { client } = createWiredClient();
+
+    await expect(client.createDataChannels()).rejects.toBeInstanceOf(DataChannelsNotConnectedError);
+    expect(client.getState().dataChannel).toMatchObject({ status: "idle" });
+    expect(client.getState().dataChannel.error).toBeInstanceOf(DataChannelsNotConnectedError);
+  });
+
+  it("moves to ready when channels are created while connected", async () => {
+    const { signalling, client } = createWiredClient();
+    signalling.emit("joined", "local-peer", [], []);
+
+    await client.createDataChannels();
+
+    expect(client.getState().dataChannel).toEqual({ status: "ready", error: null });
+  });
+
+  it("mirrors data channel errors and resets readiness", () => {
+    const { signalling, client } = createWiredClient();
+    const failure = new Error("boom");
+
+    signalling.emit("dataChannelsReady");
+    signalling.emit("dataChannelsError", failure);
+
+    expect(client.getState().dataChannel).toEqual({ status: "idle", error: failure });
+  });
+
+  it("resets readiness but preserves the error on disconnect", () => {
+    const { signalling, client } = createWiredClient();
+    const failure = new Error("boom");
+
+    signalling.emit("dataChannelsError", failure);
+    signalling.emit("dataChannelsReady");
+    signalling.emit("disconnected");
+
+    expect(client.getState().dataChannel.status).toBe("idle");
   });
 });

--- a/packages/tsunami/src/FishjamClient.ts
+++ b/packages/tsunami/src/FishjamClient.ts
@@ -25,7 +25,7 @@ import type { ScreenShareConstraints } from "./controllers/ScreenShareController
 import type { TrackPublisher } from "./controllers/TrackPublisher";
 import { VIDEO_TRACK_CONSTRAINTS } from "./devices/constraints";
 import type { IDeviceManager, PlatformMediaStream, PlatformMediaStreamTrack } from "./devices/deviceManager";
-import { DeviceManagerMissingError } from "./errors/lifecycleErrors";
+import { DataChannelsNotConnectedError, DeviceManagerMissingError } from "./errors/lifecycleErrors";
 import type {
   BandwidthLimits,
   InitializeDevicesResult,
@@ -418,12 +418,41 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
   };
 
   public createDataChannels(): Promise<void> {
-    return this.resources.run(() => this.ensureTsClient().createDataChannels());
+    return this.resources.run(async () => {
+      const { dataChannel, peerStatus } = this.store.getState();
+      if (dataChannel.status !== "idle") return;
+
+      if (peerStatus !== "connected") {
+        const error = new DataChannelsNotConnectedError();
+        this.store.update({ dataChannel: { status: "idle", error } });
+        throw error;
+      }
+
+      this.store.update({ dataChannel: { status: "creating", error: null } });
+      try {
+        await this.ensureTsClient().createDataChannels();
+      } catch (error) {
+        this.store.update({
+          dataChannel: { status: "idle", error: error instanceof Error ? error : new Error(String(error)) },
+        });
+        throw error;
+      }
+    });
   }
 
   public publishData(data: Uint8Array, options: DataChannelOptions): void {
     this.resources.assertActive();
-    this.ensureTsClient().publishData(data, options);
+    try {
+      this.ensureTsClient().publishData(data, options);
+    } catch (error) {
+      this.store.update({
+        dataChannel: {
+          ...this.store.getState().dataChannel,
+          error: error instanceof Error ? error : new Error(String(error)),
+        },
+      });
+      throw error;
+    }
   }
 
   public subscribeData(callback: DataCallback, options: DataChannelOptions): () => void {
@@ -502,7 +531,15 @@ export class FishjamClient<PeerMetadata = GenericMetadata, ServerMetadata = Gene
     this.on("reconnected", () =>
       this.store.update({ peerStatus: "connected", reconnectionStatus: "idle", ...participants() }),
     );
-    this.on("disconnected", () => this.store.update({ peerStatus: "idle", ...participants() }));
+    this.on("disconnected", () =>
+      this.store.update({
+        peerStatus: "idle",
+        dataChannel: { status: "idle", error: this.store.getState().dataChannel.error },
+        ...participants(),
+      }),
+    );
+    this.on("dataChannelsReady", () => this.store.update({ dataChannel: { status: "ready", error: null } }));
+    this.on("dataChannelsError", (error) => this.store.update({ dataChannel: { status: "idle", error } }));
     this.on("authError", () => this.store.update({ peerStatus: "error", ...reconnectionErrorIfReconnecting() }));
     this.on("joinError", () => this.store.update({ peerStatus: "error", ...reconnectionErrorIfReconnecting() }));
     this.on("connectionError", () => this.store.update({ peerStatus: "error" }));

--- a/packages/tsunami/src/errors/lifecycleErrors.ts
+++ b/packages/tsunami/src/errors/lifecycleErrors.ts
@@ -29,3 +29,16 @@ export class DeviceManagerMissingError extends FishjamError {
     this.name = "DeviceManagerMissingError";
   }
 }
+
+/**
+ * Rejected by `createDataChannels()` when the peer is not connected to a
+ * room yet; connect first, then retry.
+ */
+export class DataChannelsNotConnectedError extends FishjamError {
+  public readonly recoverability: ErrorRecoverability = "retry";
+
+  public constructor() {
+    super("Peer is not connected");
+    this.name = "DataChannelsNotConnectedError";
+  }
+}

--- a/packages/tsunami/src/index.ts
+++ b/packages/tsunami/src/index.ts
@@ -26,7 +26,11 @@ export {
 export { LocalStorageDevicePersistence } from "./devices/LocalStorageDevicePersistence";
 export { WebDeviceManager, type WebDeviceManagerOptions } from "./devices/WebDeviceManager";
 export { type ErrorRecoverability, FishjamError } from "./errors/FishjamError";
-export { ClientDisposedError, DeviceManagerMissingError } from "./errors/lifecycleErrors";
+export {
+  ClientDisposedError,
+  DataChannelsNotConnectedError,
+  DeviceManagerMissingError,
+} from "./errors/lifecycleErrors";
 export { FishjamClient, type FishjamClientConfig } from "./FishjamClient";
 export {
   buildLivestreamWhepUrl,
@@ -61,6 +65,7 @@ export {
   type ClientState,
   createInitialClientState,
   type CustomSourceState,
+  type DataChannelState,
   type LocalDeviceState,
   type PeerStatus,
   type ScreenShareState,

--- a/packages/tsunami/src/state/clientState.ts
+++ b/packages/tsunami/src/state/clientState.ts
@@ -45,6 +45,11 @@ export interface CustomSourceState {
  * Snapshots use structural sharing: an update replaces only the slices it
  * touched, so consumers can detect unchanged slices by reference equality.
  */
+export interface DataChannelState {
+  status: "idle" | "creating" | "ready";
+  error: Error | null;
+}
+
 export interface ClientState<PeerMetadata = GenericMetadata, ServerMetadata = GenericMetadata> {
   // connection
   peerStatus: PeerStatus;
@@ -60,6 +65,9 @@ export interface ClientState<PeerMetadata = GenericMetadata, ServerMetadata = Ge
   microphone: LocalDeviceState;
   screenShare: ScreenShareState;
   customSources: Record<string, CustomSourceState>;
+
+  // data channels
+  dataChannel: DataChannelState;
 
   // available hardware
   availableCameras: DeviceItem[];
@@ -91,6 +99,7 @@ export const createInitialClientState = <PeerMetadata, ServerMetadata>(): Client
   microphone: createInitialDeviceState(),
   screenShare: { stream: null, videoTrack: null, audioTrack: null, middleware: null },
   customSources: {},
+  dataChannel: { status: "idle", error: null },
   availableCameras: [],
   availableMicrophones: [],
   cameraError: null,


### PR DESCRIPTION
Stacked on #596.

## Description

- `ClientState` gains the `dataChannel` slice (`idle` / `creating` / `ready` + error).
- `createDataChannels` becomes state-aware: rejects with `DataChannelsNotConnectedError` when signalling is not connected, mirrors publish errors into the slice.
- react-client's `useDataChannel` becomes a thin store adapter.

## Motivation and Context

Data-channel state is part of the `ClientState` shape from RFC 0015 §2 (FCE-3578 scope); moving it into the store removes the last hand-tracked state in `useDataChannel`.

## Documentation impact

- [ ] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [x] No documentation update required

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
