### PR TITLE
Fix dialing on iOS when joining conference rooms

### DIFF
--- a/packages/mobile-client/src/voip/VoIPProvider.tsx
+++ b/packages/mobile-client/src/voip/VoIPProvider.tsx
@@ -71,7 +71,7 @@ export function VoIPProvider({ onWaitingCallDeclined, isVideo = false, children 
   const startNativeCallSession = useCallback(
     (to: string) =>
       Platform.OS === 'ios'
-        ? startCallKitSession({ displayName: to, handle: to, isVideo })
+        ? startCallKitSession({ displayName: to, handle: to, isVideo, isDialing: true })
         : startTelecomSession({ displayName: to, handle: to, isVideo }),
     [startCallKitSession, startTelecomSession, isVideo],
   );


### PR DESCRIPTION
## Description

Added new flag that controls whether joining the call using callkit on iOS should start dialing or no

## Motivation and Context

The issue stemmed from voip feature where we always had 

## Documentation impact

- [X] Documentation update required
- [ ] Documentation updated [in another PR](_)
- [ ] No documentation update required

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
      not work as expected)
