### PR TITLE
Release v0.30.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fishjam-web-sdk",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "license": "MIT",
   "private": true,
   "workspaces": [

--- a/packages/ios-expo-voip/package.json
+++ b/packages/ios-expo-voip/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/ios-expo-voip",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "AppDelegate glue for Fishjam VoIP on iOS — registers PushKit at launch and routes Siri/Recents call intents. Install alongside @fishjam-cloud/react-native-client when VoIP options are enabled.",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/mobile-client/package.json
+++ b/packages/mobile-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-native-client",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "React Native client library for Fishjam",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/react-client/package.json
+++ b/packages/react-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-client",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "React client library for Fishjam",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/react-native-custom-video-source/package.json
+++ b/packages/react-native-custom-video-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-native-custom-video-source",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Publish your own video frames to Fishjam — forward native buffers or render into a WebGPU surface pool, from any frame source",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/react-native-vision-camera-source/package.json
+++ b/packages/react-native-vision-camera-source/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/react-native-vision-camera-source",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "VisionCamera frame outputs that publish camera frames to Fishjam — zero-copy forwarding and WebGPU-rendered video sources",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/ts-client/package.json
+++ b/packages/ts-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/ts-client",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Typescript client library for Fishjam",
   "license": "Apache-2.0",
   "author": "Fishjam Team",

--- a/packages/webrtc-client/package.json
+++ b/packages/webrtc-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fishjam-cloud/webrtc-client",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Typescript client library for ExWebRTC/WebRTC endpoint in Membrane RTC Engine",
   "license": "Apache-2.0",
   "author": "Fishjam Team",


### PR DESCRIPTION
## Description

Release v0.30.1 — bumps the root + all published workspaces `0.30.0` → `0.30.1`, and points the `react-native-webrtc` submodule at `v0.30.3`.